### PR TITLE
Added multi-team support for up to 8 teams

### DIFF
--- a/ai_arena/arena_ratings.json
+++ b/ai_arena/arena_ratings.json
@@ -1,74 +1,74 @@
 {
   "coward_bot": {
-    "rating": 1010.4133409273157,
-    "wins": 9,
-    "losses": 8,
-    "draws": 5
+    "rating": 1027.9414266549704,
+    "wins": 28,
+    "losses": 24,
+    "draws": 21
   },
   "easy": {
-    "rating": 1024.6016802766053,
-    "wins": 7,
-    "losses": 7,
-    "draws": 8
+    "rating": 953.8651237916822,
+    "wins": 17,
+    "losses": 30,
+    "draws": 26
   },
   "example": {
-    "rating": 923.8764885275048,
-    "wins": 3,
-    "losses": 10,
-    "draws": 9
+    "rating": 900.6263465271462,
+    "wins": 12,
+    "losses": 42,
+    "draws": 19
   },
   "hard": {
-    "rating": 1040.9895951609917,
-    "wins": 8,
-    "losses": 4,
-    "draws": 10
+    "rating": 1091.4372453767278,
+    "wins": 32,
+    "losses": 7,
+    "draws": 34
   },
   "hard_bot_2": {
-    "rating": 1186.837486693192,
-    "wins": 19,
-    "losses": 1,
-    "draws": 2
+    "rating": 1174.272313015511,
+    "wins": 42,
+    "losses": 5,
+    "draws": 26
   },
   "kite_bot": {
-    "rating": 1121.8031169600013,
-    "wins": 15,
-    "losses": 2,
-    "draws": 5
-  },
-  "medium": {
-    "rating": 979.7765484679629,
-    "wins": 3,
-    "losses": 5,
+    "rating": 1267.2276134490821,
+    "wins": 55,
+    "losses": 4,
     "draws": 14
   },
-  "null": {
-    "rating": 942.546347480957,
-    "wins": 0,
-    "losses": 5,
-    "draws": 17
+  "medium": {
+    "rating": 1032.6491984947022,
+    "wins": 25,
+    "losses": 25,
+    "draws": 23
   },
-  "perigee": {
-    "rating": 878.0432650176505,
+  "null": {
+    "rating": 893.7035076810186,
+    "wins": 13,
+    "losses": 32,
+    "draws": 28
+  },
+  "Peri": {
+    "rating": 597.7335235350286,
     "wins": 0,
-    "losses": 12,
-    "draws": 10
+    "losses": 66,
+    "draws": 1
   },
   "terror_bot": {
-    "rating": 1053.4109530776327,
-    "wins": 10,
-    "losses": 3,
-    "draws": 9
+    "rating": 1067.6607160988297,
+    "wins": 36,
+    "losses": 16,
+    "draws": 21
   },
   "turtle": {
-    "rating": 958.4407480228524,
-    "wins": 1,
-    "losses": 5,
-    "draws": 16
+    "rating": 1058.745613430602,
+    "wins": 20,
+    "losses": 13,
+    "draws": 40
   },
   "wander": {
-    "rating": 879.2604293873335,
-    "wins": 1,
-    "losses": 14,
-    "draws": 7
+    "rating": 934.5040624062603,
+    "wins": 12,
+    "losses": 37,
+    "draws": 24
   }
 }

--- a/ais/_peri.py
+++ b/ais/_peri.py
@@ -73,11 +73,8 @@ class Peri(BaseAI):
         self.num_medics = 0
         self.num_snipers = 0
 
-        self.mid = self.bounds[0] / 2
-
     def on_start(self) -> None:
         self.set_build("sniper")
-        self.region = (0, self.mid) if _pos(self.get_cc()).x < self.mid else (self.mid, self.bounds[0])
 
     def on_step(self, iteration: int) -> None:
         self.setup_step()
@@ -123,7 +120,14 @@ class Peri(BaseAI):
                 self.move_unit(unit, self.team_target.x, self.team_target.y)
 
     def in_our_half(self, pos:Vector2):
-        return self.region[0] <= pos.x <= self.region[1]
+        """Check if position is on our side using CC-relative distance."""
+        # Create a lightweight object with x, y for is_on_own_side
+        class _Pos:
+            __slots__ = ('x', 'y')
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+        return self.is_on_own_side(_Pos(pos.x, pos.y))
 
     def get_metal_spot_flag(self, metal_spot:MetalSpot):
         pos = _pos(metal_spot)

--- a/ais/coward_bot.py
+++ b/ais/coward_bot.py
@@ -123,9 +123,9 @@ class CowardBot(BaseAI):
         if unclaimed:
             nearest = min(unclaimed, key=lambda s: (s.x - cc.x) ** 2 + (s.y - cc.y) ** 2)
             return (nearest.x, nearest.y)
-        # All spots ours — fall back to behind base
-        direction = -1 if (cc and cc.x < self.bounds[0] / 2) else 1
-        return (cc.x + direction * 60, cc.y)
+        # All spots ours — fall back to behind base (away from enemy)
+        ex, ey = self.get_enemy_direction()
+        return (cc.x - ex * 60, cc.y - ey * 60)
 
     @staticmethod
     def _closest(unit, targets):

--- a/ais/hard_ai.py
+++ b/ais/hard_ai.py
@@ -34,7 +34,6 @@ class HardAI(BaseAI):
         own = self.get_own_mobile_units()
         enemies = self.get_enemy_units()
         bw, bh = self.bounds
-        mid_x = bw / 2.0
 
         scouts = [u for u in own if u.unit_type == "scout"]
         tanks = [u for u in own if u.unit_type == "tank"]
@@ -66,8 +65,8 @@ class HardAI(BaseAI):
 
         self._command_scouts(scouts, enemies, enemy_mobile, cc, bw, bh)
         self._command_shockwaves(shockwaves, enemy_mobile, cc)
-        self._command_snipers(snipers, enemies, enemy_mobile, cc, mid_x)
-        self._command_tanks(tanks, enemies, enemy_mobile, cc, mid_x)
+        self._command_snipers(snipers, enemies, enemy_mobile, cc)
+        self._command_tanks(tanks, enemies, enemy_mobile, cc)
         self._command_generic(soldiers, enemy_mobile, cc)
         self._command_generic(machine_gunners, enemy_mobile, cc)
         self._command_medics(medics, own, cc)
@@ -155,10 +154,8 @@ class HardAI(BaseAI):
 
     # -- helpers ---------------------------------------------------------------
 
-    def _on_our_side(self, entity, mid_x: float) -> bool:
-        cc = self.get_cc()
-        on_left = (cc.x < mid_x) if cc else True
-        return (entity.x < mid_x) if on_left else (entity.x > mid_x)
+    def _on_our_side(self, entity) -> bool:
+        return self.is_on_own_side(entity)
 
     def _flee_from(self, unit, threat, dist: float) -> None:
         dx = unit.x - threat.x
@@ -343,7 +340,7 @@ class HardAI(BaseAI):
                 d = math.hypot(dx, dy) or 1.0
                 self.move_unit(sniper, sniper.x + (dx / d) * 20, sniper.y + (dy / d) * 20)
 
-    def _command_snipers(self, snipers, enemies, enemy_mobile, cc, mid_x):
+    def _command_snipers(self, snipers, enemies, enemy_mobile, cc):
         if not snipers:
             return
 
@@ -401,13 +398,13 @@ class HardAI(BaseAI):
             d = math.hypot(dx, dy) or 1.0
             self.move_unit(tank, tank.x + (dx / d) * 10, tank.y + (dy / d) * 10)
 
-    def _command_tanks(self, tanks, enemies, enemy_mobile, cc, mid_x):
+    def _command_tanks(self, tanks, enemies, enemy_mobile, cc):
         if not tanks:
             return
 
         enemy_snipers_our_side = [
             e for e in enemy_mobile
-            if e.unit_type == "sniper" and self._on_our_side(e, mid_x)
+            if e.unit_type == "sniper" and self._on_our_side(e)
         ]
 
         for tank in tanks:

--- a/ais/hard_bot_2.py
+++ b/ais/hard_bot_2.py
@@ -40,7 +40,6 @@ class HardBot2(BaseAI):
         own = self.get_own_mobile_units()
         enemies = self.get_enemy_units()
         bw, bh = self.bounds
-        mid_x = bw / 2.0
 
         scouts = [u for u in own if u.unit_type == "scout"]
         tanks = [u for u in own if u.unit_type == "tank"]
@@ -81,8 +80,8 @@ class HardBot2(BaseAI):
 
         self._command_scouts(scouts, enemies, enemy_mobile, cc, bw, bh)
         self._command_shockwaves(shockwaves, enemy_mobile, cc)
-        self._command_snipers(snipers, enemies, enemy_mobile, cc, mid_x, tanks)
-        self._command_tanks(tanks, enemies, enemy_mobile, cc, mid_x)
+        self._command_snipers(snipers, enemies, enemy_mobile, cc, tanks)
+        self._command_tanks(tanks, enemies, enemy_mobile, cc)
         self._command_generic(soldiers, enemy_mobile, cc)
         self._command_generic(machine_gunners, enemy_mobile, cc)
         self._command_medics(medics, own, cc)
@@ -178,10 +177,8 @@ class HardBot2(BaseAI):
 
     # -- helpers ---------------------------------------------------------------
 
-    def _on_our_side(self, entity, mid_x: float) -> bool:
-        cc = self.get_cc()
-        on_left = (cc.x < mid_x) if cc else True
-        return (entity.x < mid_x) if on_left else (entity.x > mid_x)
+    def _on_our_side(self, entity) -> bool:
+        return self.is_on_own_side(entity)
 
     def _flee_from(self, unit, threat, dist: float) -> None:
         dx = unit.x - threat.x
@@ -373,7 +370,7 @@ class HardBot2(BaseAI):
                 d = math.hypot(dx, dy) or 1.0
                 self.move_unit(sniper, sniper.x + (dx / d) * 20, sniper.y + (dy / d) * 20)
 
-    def _command_snipers(self, snipers, enemies, enemy_mobile, cc, mid_x, tanks):
+    def _command_snipers(self, snipers, enemies, enemy_mobile, cc, tanks):
         if not snipers:
             return
 
@@ -431,13 +428,13 @@ class HardBot2(BaseAI):
             d = math.hypot(dx, dy) or 1.0
             self.move_unit(tank, tank.x + (dx / d) * 10, tank.y + (dy / d) * 10)
 
-    def _command_tanks(self, tanks, enemies, enemy_mobile, cc, mid_x):
+    def _command_tanks(self, tanks, enemies, enemy_mobile, cc):
         if not tanks:
             return
 
         enemy_snipers_our_side = [
             e for e in enemy_mobile
-            if e.unit_type == "sniper" and self._on_our_side(e, mid_x)
+            if e.unit_type == "sniper" and self._on_our_side(e)
         ]
 
         for tank in tanks:

--- a/ais/kite_bot.py
+++ b/ais/kite_bot.py
@@ -105,9 +105,9 @@ class KiteBot(BaseAI):
                 self.move_unit(sniper, away_x, away_y)
 
     def _rally_point(self, cc):
-        """60px from CC toward own side (team 1 left, team 2 right)."""
-        direction = -1 if (cc and cc.x < self.bounds[0] / 2) else 1
-        return (cc.x + direction * 60, cc.y)
+        """60px from CC away from enemy (toward own side)."""
+        ex, ey = self.get_enemy_direction()
+        return (cc.x - ex * 60, cc.y - ey * 60)
 
     @staticmethod
     def _closest(unit, targets):

--- a/ais/medium_ai.py
+++ b/ais/medium_ai.py
@@ -28,7 +28,6 @@ class MediumAI(BaseAI):
         own = self.get_own_mobile_units()
         enemies = self.get_enemy_units()
         bw, bh = self.bounds
-        mid_x = bw / 2.0
 
         scouts = [u for u in own if u.unit_type == "scout"]
         tanks = [u for u in own if u.unit_type == "tank"]
@@ -45,10 +44,10 @@ class MediumAI(BaseAI):
         self._last_unit_count = current_count
 
         self._update_build(scouts, tanks, snipers, medics)
-        self._command_scouts(scouts, enemies, cc, mid_x, bw, bh)
-        self._command_tanks(tanks, enemies, cc, mid_x)
+        self._command_scouts(scouts, enemies, cc, bw, bh)
+        self._command_tanks(tanks, enemies, cc)
         self._command_medics(medics, tanks, cc)
-        self._command_snipers(snipers, enemies, tanks, cc, mid_x)
+        self._command_snipers(snipers, enemies, tanks, cc)
 
     # -- build order --------------------------------------------------------
 
@@ -83,14 +82,12 @@ class MediumAI(BaseAI):
 
     # -- helpers ------------------------------------------------------------
 
-    def _on_our_side(self, entity, mid_x: float) -> bool:
-        cc = self.get_cc()
-        on_left = (cc.x < mid_x) if cc else True
-        return (entity.x < mid_x) if on_left else (entity.x > mid_x)
+    def _on_our_side(self, entity) -> bool:
+        return self.is_on_own_side(entity)
 
     # -- scout behavior -----------------------------------------------------
 
-    def _command_scouts(self, scouts, enemies, cc, mid_x, bw, bh):
+    def _command_scouts(self, scouts, enemies, cc, bw, bh):
         if not scouts:
             return
 
@@ -174,14 +171,14 @@ class MediumAI(BaseAI):
 
     # -- tank behavior ------------------------------------------------------
 
-    def _command_tanks(self, tanks, enemies, cc, mid_x):
+    def _command_tanks(self, tanks, enemies, cc):
         if not tanks:
             return
 
         # Prioritize enemy snipers on our side of the map
         enemy_snipers_our_side = [
             e for e in enemies
-            if e.unit_type == "sniper" and self._on_our_side(e, mid_x)
+            if e.unit_type == "sniper" and self._on_our_side(e)
         ]
 
         pushing = len(tanks) >= 4 or enemy_snipers_our_side
@@ -254,12 +251,12 @@ class MediumAI(BaseAI):
 
     # -- sniper behavior ----------------------------------------------------
 
-    def _command_snipers(self, snipers, enemies, tanks, cc, mid_x):
+    def _command_snipers(self, snipers, enemies, tanks, cc):
         if not snipers or not enemies:
             return
 
         enemy_snipers = [e for e in enemies if e.unit_type == "sniper"]
-        enemies_our_side = [e for e in enemies if self._on_our_side(e, mid_x)]
+        enemies_our_side = [e for e in enemies if self._on_our_side(e)]
         enemy_extractors = [e for e in self.get_metal_extractors()
                             if e.team != self._team]
 

--- a/ais/terror_bot.py
+++ b/ais/terror_bot.py
@@ -125,9 +125,9 @@ class TerrorBot(BaseAI):
         if unclaimed:
             nearest = min(unclaimed, key=lambda s: (s.x - cc.x) ** 2 + (s.y - cc.y) ** 2)
             return (nearest.x, nearest.y)
-        # All spots ours — fall back to behind base
-        direction = -1 if (cc and cc.x < self.bounds[0] / 2) else 1
-        return (cc.x + direction * 60, cc.y)
+        # All spots ours — fall back to behind base (away from enemy)
+        ex, ey = self.get_enemy_direction()
+        return (cc.x - ex * 60, cc.y - ey * 60)
 
     @staticmethod
     def _closest(unit, targets):

--- a/app.py
+++ b/app.py
@@ -310,10 +310,13 @@ class App:
         screen_w = self._screen.get_width()
         screen_h = self._screen.get_height()
 
+        # Build player_team from lobby data or default to 1v1
+        mp_player_team = data.get("player_team", {1: 1, 2: 2})
+
         replay_config = {
             "player_ai_ids": {},
             "player_ai_names": {},
-            "player_team": {1: 1, 2: 2},
+            "player_team": mp_player_team,
             "obstacle_count": list(obs),
             "player_name": host_name,
         }
@@ -325,7 +328,7 @@ class App:
             height=height,
             map_generator=DefaultMapGenerator(obstacle_count=obs),
             player_ai={},  # both teams human
-            player_team={1: 1, 2: 2},
+            player_team=mp_player_team,
             screen=self._screen,
             clock=self._clock,
             replay_config=replay_config,
@@ -377,7 +380,8 @@ class App:
             "human_teams": result.get("human_teams", set()),
             "stats": result.get("stats"),
             "replay_filepath": result.get("replay_filepath"),
-            "team_names": {1: host_name, 2: client_name},
+            "team_names": {t: (host_name if pid == 1 else client_name)
+                           for pid, t in mp_player_team.items()},
         })
 
     def _run_mp_client_game(self, data: dict) -> ScreenResult:

--- a/config/settings.py
+++ b/config/settings.py
@@ -24,12 +24,27 @@ PLAYER_COLORS = [
 ]
 
 # Per-team colours used for team-scoped visuals (capture arcs, minimap borders)
-TEAM_COLORS = {1: (80, 140, 255), 2: (255, 80, 80)}
+TEAM_COLORS = {
+    1: (80,  140, 255),  # T1 blue
+    2: (255,  80,  80),  # T2 red
+    3: (80,  220, 160),  # T3 teal
+    4: (255, 160,  60),  # T4 orange
+    5: (180,  80, 220),  # T5 purple
+    6: (80,  220, 220),  # T6 cyan
+    7: (220, 220,  80),  # T7 yellow
+    8: (220,  80, 160),  # T8 pink
+}
 
 # Backward-compat aliases (metal_spot.py / metal_extractor.py still reference these)
-TEAM1_COLOR = PLAYER_COLORS[0]
+TEAM1_COLOR = TEAM_COLORS[1]
 TEAM1_SELECTED_COLOR = (150, 220, 255)
-TEAM2_COLOR = PLAYER_COLORS[2]
+TEAM2_COLOR = TEAM_COLORS[2]
+TEAM3_COLOR = TEAM_COLORS[3]
+TEAM4_COLOR = TEAM_COLORS[4]
+TEAM5_COLOR = TEAM_COLORS[5]
+TEAM6_COLOR = TEAM_COLORS[6]
+TEAM7_COLOR = TEAM_COLORS[7]
+TEAM8_COLOR = TEAM_COLORS[8]
 PATH_COLOR_TEAM1 = (80, 140, 255, 100)
 PATH_DOT_COLOR = (255, 255, 255, 160)
 

--- a/entities/command_center.py
+++ b/entities/command_center.py
@@ -23,7 +23,7 @@ class CommandCenter(Unit):
             damage=CC_LASER_DAMAGE,
             range=CC_LASER_RANGE,
             cooldown=CC_LASER_COOLDOWN,
-            laser_color=PLAYER_COLORS[player_id - 1],
+            laser_color=PLAYER_COLORS[(player_id - 1) % len(PLAYER_COLORS)],
             laser_width=2,
         )
         self.attack_damage = self.weapon.damage

--- a/entities/metal_extractor.py
+++ b/entities/metal_extractor.py
@@ -62,7 +62,7 @@ class MetalExtractor(Unit):
     def _finish_watch_tower(self):
         self.upgrade_state = "watch_tower"
         self.upgrade_timer = 0.0
-        color = PLAYER_COLORS[self.player_id - 1] if self.player_id >= 1 else PLAYER_COLORS[0]
+        color = PLAYER_COLORS[(self.player_id - 1) % len(PLAYER_COLORS)] if self.player_id >= 1 else PLAYER_COLORS[0]
         self.weapon = Weapon(
             name="Laser",
             damage=WATCH_TOWER_LASER_DAMAGE,

--- a/entities/metal_spot.py
+++ b/entities/metal_spot.py
@@ -14,28 +14,53 @@ class MetalSpot(CircleEntity, Damageable):
         super().__init__(x, y, METAL_SPOT_RADIUS)
         self.color = METAL_SPOT_COLOR
         self.owner: int | None = None
-        self.capture_progress: float = 0.0  # -1.0 to 1.0 representing the capture progress for each team
+        self.capture_progress: dict[int, float] = {}  # team_id -> 0.0..1.0
         self.no_decay: bool = False  # when True, neutral drift toward 0 is suppressed
 
-    def update_progress(self, unit_difference: float, dt: float):
-        # unit_difference is team 1 units - team 2 units (scouts count as 0.3)
+    def update_progress(self, team_counts: dict[int, float], dt: float):
+        """Update capture progress based on per-team unit presence.
+
+        team_counts maps team_id -> weighted unit count near this spot.
+        The team with strictly more presence than all others combined gains
+        progress; all other teams' progress decays.
+        """
         if self.owner is not None:
             return
 
-        if unit_difference != 0:
-            self.capture_progress += unit_difference * METAL_SPOT_CAPTURE_RATE * dt
-        elif self.capture_progress != 0 and not self.no_decay:
-            # Decay at 1% per second when no one is capturing
-            decay = 0.01 * dt
-            if self.capture_progress > 0:
-                self.capture_progress = max(0.0, self.capture_progress - decay)
+        # Find dominant team (must have strict majority over all others combined)
+        total = sum(team_counts.values())
+        dominant_team = None
+        dominant_count = 0.0
+        for tid, count in team_counts.items():
+            if count > 0 and count > dominant_count:
+                dominant_count = count
+                dominant_team = tid
+
+        others_count = total - dominant_count
+        has_majority = dominant_team is not None and dominant_count > others_count
+
+        if has_majority:
+            net = dominant_count - others_count
+            prog = self.capture_progress.get(dominant_team, 0.0)
+            prog += net * METAL_SPOT_CAPTURE_RATE * dt
+            self.capture_progress[dominant_team] = min(1.0, prog)
+
+        # Decay non-dominant teams' progress
+        for tid in list(self.capture_progress):
+            if tid == dominant_team and has_majority:
+                continue
+            if self.no_decay and not has_majority:
+                continue
+            val = self.capture_progress[tid]
+            val = max(0.0, val - 0.01 * dt)
+            if val <= 0.0:
+                del self.capture_progress[tid]
             else:
-                self.capture_progress = min(0.0, self.capture_progress + decay)
-        self.capture_progress = min(1.0, max(-1.0, self.capture_progress))
+                self.capture_progress[tid] = val
 
     def claim(self, team: int):
         self.owner = team
-        self.capture_progress = 0.0
+        self.capture_progress = {}
 
     def release(self):
         self.owner = None
@@ -58,21 +83,24 @@ class MetalSpot(CircleEntity, Damageable):
         if self.owner is not None:
             return
 
-        # draw the capture progress pie chart
-        _default_arc = (200, 200, 60)
-        progress_color = (TEAM_COLORS.get(1, _default_arc) if self.capture_progress > 0
-                          else TEAM_COLORS.get(2, _default_arc))
+        # draw capture progress arcs (one per contesting team)
+        if not self.capture_progress:
+            return
         arc_r = METAL_SPOT_CAPTURE_RADIUS + METAL_SPOT_CAPTURE_ARC_WIDTH
-        start_angle = math.pi / 2
-        end_angle = start_angle + self.capture_progress * math.tau
-        if self.capture_progress > 0:
-            a = start_angle
-            b = end_angle
-        else:
-            a = end_angle
-            b = start_angle
-        rect = pygame.Rect(int(self.x - arc_r), int(self.y - arc_r), int(arc_r * 2), int(arc_r * 2))
-        pygame.draw.arc(surface, progress_color, rect, a, b, int(METAL_SPOT_CAPTURE_ARC_WIDTH))
+        rect = pygame.Rect(int(self.x - arc_r), int(self.y - arc_r),
+                           int(arc_r * 2), int(arc_r * 2))
+        arc_w = int(METAL_SPOT_CAPTURE_ARC_WIDTH)
+        teams_contesting = sorted(self.capture_progress.keys())
+        n = len(teams_contesting)
+        for i, tid in enumerate(teams_contesting):
+            prog = self.capture_progress[tid]
+            if abs(prog) < 0.01:
+                continue
+            tc = TEAM_COLORS.get(tid, (200, 200, 60))
+            # Each team's arc starts at an offset so they don't overlap
+            base_angle = math.pi / 2 + (2 * math.pi * i / max(n, 1))
+            end_angle = base_angle + prog * (2 * math.pi / max(n, 1))
+            pygame.draw.arc(surface, tc, rect, base_angle, end_angle, arc_w)
 
     # -- serialization --------------------------------------------------------
 
@@ -80,7 +108,7 @@ class MetalSpot(CircleEntity, Damageable):
         d = super().to_dict()
         d.update({
             "owner": self.owner,
-            "capture_progress": self.capture_progress,
+            "capture_progress": {str(tid): val for tid, val in self.capture_progress.items()},
         })
         return d
 
@@ -93,5 +121,17 @@ class MetalSpot(CircleEntity, Damageable):
         ms.obstacle = data["obstacle"]
         ms.alive = data["alive"]
         ms.owner = data["owner"]
-        ms.capture_progress = data["capture_progress"]
+        raw_cp = data.get("capture_progress", {})
+        if isinstance(raw_cp, dict):
+            ms.capture_progress = {int(k): v for k, v in raw_cp.items()}
+        elif isinstance(raw_cp, (int, float)):
+            # Legacy format: float from -1.0 to 1.0
+            if raw_cp >= 0 and raw_cp > 0.001:
+                ms.capture_progress = {1: float(raw_cp)}
+            elif raw_cp < -0.001:
+                ms.capture_progress = {2: abs(float(raw_cp))}
+            else:
+                ms.capture_progress = {}
+        else:
+            ms.capture_progress = {}
         return ms

--- a/entities/unit.py
+++ b/entities/unit.py
@@ -53,7 +53,7 @@ class Unit(CircleEntity, Damageable):
         self.player_id = player_id
         self.is_t2: bool = stats.get("is_t2", False)
         self.speed: float = stats["speed"]
-        self.color = PLAYER_COLORS[player_id - 1]
+        self.color = PLAYER_COLORS[(player_id - 1) % len(PLAYER_COLORS)]
         self._base_color = self.color
 
         self.max_hp: float = stats["hp"]
@@ -62,7 +62,7 @@ class Unit(CircleEntity, Damageable):
 
         wdata = stats.get("weapon")
         if wdata:
-            laser_color = wdata.get("laser_color", PLAYER_COLORS[player_id - 1])
+            laser_color = wdata.get("laser_color", PLAYER_COLORS[(player_id - 1) % len(PLAYER_COLORS)])
             if wdata.get("hits_only_friendly", False):
                 laser_color = HEAL_LASER_COLOR
             self.weapon = Weapon(

--- a/game.py
+++ b/game.py
@@ -218,8 +218,10 @@ class Game:
         if player_team is not None:
             self.player_team: dict[int, int] = player_team
         else:
-            # Default: each player is their own team (1v1 / AI-vs-AI)
-            _all_pids = set(self.player_ai.keys()) | {1, 2}
+            # Default: each player is their own team
+            _all_pids = set(self.player_ai.keys())
+            if len(_all_pids) < 2:
+                _all_pids |= {1, 2}  # backward compat: bare Game() gets 1v1
             self.player_team = {p: p for p in _all_pids}
 
         self.all_teams: set[int] = set(self.player_team.values())
@@ -1097,13 +1099,13 @@ class Game:
                 self._iteration, self.entities, self.laser_flashes,
             )
 
-        # -- win condition: check if < all teams have a living CC ---------------
+        # -- win condition: game ends when <= 1 team has a living CC ---------------
         surviving_teams = {cc.team for cc in self.command_centers if cc.alive}
-        if len(surviving_teams) < len(self.all_teams) and self._winner == 0:
+        if len(surviving_teams) <= 1 and self._winner == 0:
             if len(surviving_teams) == 1:
                 self._winner = next(iter(surviving_teams))
             else:
-                self._winner = -1  # draw
+                self._winner = -1  # draw (all CCs dead)
             # Transition to explode phase instead of ending immediately
             self._phase = "explode"
             self._anim_timer = 0.0
@@ -1112,9 +1114,13 @@ class Game:
             for t in losing_teams:
                 self._init_fragments(t)
 
-        # Tick limit — force draw if exceeded
+        # Tick limit — score-based tiebreaker, then draw if still tied
         if self._max_ticks > 0 and self._iteration >= self._max_ticks and self._winner == 0:
-            self._winner = -1
+            scores = {t: self._stats.compute_score(t, self.entities, 0)
+                      for t in self.all_teams}
+            max_score = max(scores.values()) if scores else 0
+            top = [t for t, s in scores.items() if s == max_score]
+            self._winner = top[0] if len(top) == 1 else -1
             self._phase = "explode"
             self._anim_timer = 0.0
         self._stats.record_subsystem("bookkeeping", (_perf() - _t) * 1000)
@@ -1276,7 +1282,7 @@ class Game:
                 bonus_pct = entity.get_total_bonus_percent()
                 if bonus_pct > 0:
                     name = f"{name} (+{bonus_pct}%)"
-                label_color = PLAYER_COLORS[entity.player_id - 1]
+                label_color = PLAYER_COLORS[(entity.player_id - 1) % len(PLAYER_COLORS)]
                 name_surf = self._label_font.render(name, True, label_color)
                 nx = int(entity.x) - name_surf.get_width() // 2
                 ny = int(entity.y) - 40
@@ -1569,7 +1575,7 @@ class Game:
 
         # Command centers
         for cc in self.command_centers:
-            col = PLAYER_COLORS[cc.player_id - 1]
+            col = PLAYER_COLORS[(cc.player_id - 1) % len(PLAYER_COLORS)]
             pygame.draw.circle(surf, col,
                                (int(cc.x * sx), int(cc.y * sy)), 5)
             pygame.draw.circle(surf, (255, 255, 255),
@@ -1579,7 +1585,7 @@ class Game:
         for u in self.units:
             if u.is_building or not u.alive:
                 continue
-            col = PLAYER_COLORS[u.player_id - 1]
+            col = PLAYER_COLORS[(u.player_id - 1) % len(PLAYER_COLORS)]
             r = 2 if u.unit_type != "tank" else 3
             pygame.draw.circle(surf, col,
                                (int(u.x * sx), int(u.y * sy)), r)

--- a/gui.py
+++ b/gui.py
@@ -342,7 +342,7 @@ def _draw_group_grid(screen: pygame.Surface, r: pygame.Rect,
         cx, cy = box.centerx, box.centery
         stats = UNIT_TYPES.get(unit.unit_type, {})
         sym = stats.get("symbol")
-        base_color = PLAYER_COLORS[unit.player_id - 1]
+        base_color = PLAYER_COLORS[(unit.player_id - 1) % len(PLAYER_COLORS)]
 
         if _is_cc(unit):
             pts = hexagon_points(bs * 0.3)
@@ -387,7 +387,7 @@ def _draw_portrait(screen: pygame.Surface, r: pygame.Rect,
 
     stats = UNIT_TYPES.get(unit.unit_type, {})
     sym = stats.get("symbol")
-    base_color = PLAYER_COLORS[unit.player_id - 1]
+    base_color = PLAYER_COLORS[(unit.player_id - 1) % len(PLAYER_COLORS)]
 
     if _is_cc(unit):
         pts = hexagon_points(sz * 0.35)

--- a/main.py
+++ b/main.py
@@ -9,9 +9,13 @@ def main():
     parser.add_argument("--headless", action="store_true",
                         help="Run in headless mode (AI vs AI, no rendering, auto-exit)")
     parser.add_argument("--team1", type=str, default=None,
-                        help="AI id for team 1 (e.g. 'wander')")
+                        help="AI id for team 1 (e.g. 'wander') — 1v1 shorthand")
     parser.add_argument("--team2", type=str, default=None,
-                        help="AI id for team 2 (e.g. 'wander')")
+                        help="AI id for team 2 (e.g. 'wander') — 1v1 shorthand")
+    parser.add_argument("--teams", type=str, default=None,
+                        help="Comma-separated AI ids for FFA (e.g. 'wander,easy,hard')")
+    parser.add_argument("--player", action="append", default=None,
+                        help="Player spec: 'pid:team:ai_id' (repeatable)")
     parser.add_argument("--width", type=int, default=800,
                         help="Map width (default: 800)")
     parser.add_argument("--height", type=int, default=600,
@@ -117,21 +121,46 @@ def _run_headless(args):
     registry = AIRegistry()
     registry.discover()
     choices = registry.get_choices()
-    ai_ids = [c[0] for c in choices]
+    valid_ids = {c[0] for c in choices}
 
-    # Default to first available AI if not specified
-    t1_id = args.team1 or (ai_ids[0] if ai_ids else "wander")
-    t2_id = args.team2 or (ai_ids[0] if ai_ids else "wander")
+    # Build player_ai and player_team from args
+    player_ai = {}
+    player_team = {}
 
-    for label, ai_id in [("team1", t1_id), ("team2", t2_id)]:
-        if ai_id not in [c[0] for c in choices]:
-            print(f"[AIRTS] Unknown AI '{ai_id}' for {label}. Use --list-ais to see options.")
-            sys.exit(1)
-
-    team_ai = {
-        1: registry.create(t1_id),
-        2: registry.create(t2_id),
-    }
+    if args.player:
+        # Explicit --player pid:team:ai_id specs
+        for spec in args.player:
+            parts = spec.split(":")
+            if len(parts) != 3:
+                print(f"[AIRTS] Invalid --player spec '{spec}'. Format: pid:team:ai_id")
+                sys.exit(1)
+            pid, tid, ai_id = int(parts[0]), int(parts[1]), parts[2]
+            if ai_id not in valid_ids:
+                print(f"[AIRTS] Unknown AI '{ai_id}'. Use --list-ais to see options.")
+                sys.exit(1)
+            player_ai[pid] = registry.create(ai_id)
+            player_team[pid] = tid
+    elif args.teams:
+        # FFA shorthand: --teams "wander,easy,hard"
+        ai_list = [s.strip() for s in args.teams.split(",") if s.strip()]
+        for i, ai_id in enumerate(ai_list):
+            if ai_id not in valid_ids:
+                print(f"[AIRTS] Unknown AI '{ai_id}'. Use --list-ais to see options.")
+                sys.exit(1)
+            pid = i + 1
+            player_ai[pid] = registry.create(ai_id)
+            player_team[pid] = pid  # each player on own team (FFA)
+    else:
+        # Legacy --team1/--team2 (1v1)
+        ai_ids_list = [c[0] for c in choices]
+        t1_id = args.team1 or (ai_ids_list[0] if ai_ids_list else "wander")
+        t2_id = args.team2 or (ai_ids_list[0] if ai_ids_list else "wander")
+        for label, ai_id in [("team1", t1_id), ("team2", t2_id)]:
+            if ai_id not in valid_ids:
+                print(f"[AIRTS] Unknown AI '{ai_id}' for {label}. Use --list-ais to see options.")
+                sys.exit(1)
+        player_ai = {1: registry.create(t1_id), 2: registry.create(t2_id)}
+        player_team = {1: 1, 2: 2}
 
     obs = (args.obs_min, args.obs_max)
     max_ticks = args.time_limit * 60 * 60 if args.time_limit > 0 else 0
@@ -142,10 +171,17 @@ def _run_headless(args):
     pygame.display.set_caption("AIRTS — Headless")
     clock = pygame.time.Clock()
 
-    team_ai_ids = {1: t1_id, 2: t2_id}
+    # Build replay config
+    ai_ids_map = {}
+    ai_names_map = {}
+    for pid, ai in player_ai.items():
+        ai_ids_map[pid] = ai.ai_id
+        ai_names_map[pid] = ai.ai_name
+
     replay_config = {
-        "team_ai_ids": team_ai_ids,
-        "team_ai_names": {t: ai.ai_name for t, ai in team_ai.items()},
+        "player_ai_ids": ai_ids_map,
+        "player_ai_names": ai_names_map,
+        "player_team": player_team,
         "obstacle_count": list(obs),
         "player_name": "Headless",
     }
@@ -154,7 +190,8 @@ def _run_headless(args):
         width=args.width,
         height=args.height,
         map_generator=DefaultMapGenerator(obstacle_count=obs),
-        team_ai=team_ai,
+        player_ai=player_ai,
+        player_team=player_team,
         screen=screen,
         clock=clock,
         replay_config=replay_config,

--- a/networking/client.py
+++ b/networking/client.py
@@ -33,7 +33,7 @@ class GameClient:
         self._outbound_commands: queue.Queue[str] = queue.Queue()
 
         # Connection state
-        self.player_id: int = 2  # assigned by host in lobby_info
+        self.player_id: int = 0  # assigned by host in lobby_info
         self.host_name: str = ""
         self.map_width: int = 800
         self.map_height: int = 600
@@ -56,8 +56,10 @@ class GameClient:
 
     @property
     def client_team(self) -> int:
-        """Legacy alias for player_id (1v1: player_id == team)."""
-        return self.player_id
+        """Team this client belongs to, derived from player_team mapping."""
+        if self.player_team and self.player_id in self.player_team:
+            return self.player_team[self.player_id]
+        return self.player_id  # fallback for legacy 1v1
 
     @property
     def connected(self) -> bool:

--- a/screens/arena_screen.py
+++ b/screens/arena_screen.py
@@ -10,10 +10,10 @@ from ui.theme import (
     MENU_BG, CONTENT_TEXT, HEADING_FONT_SIZE, CONTENT_FONT_SIZE,
     BTN_WIDTH, BTN_HEIGHT,
 )
-from ui.widgets import Button, BackButton, Slider, _get_font
+from ui.widgets import Button, BackButton, Slider, Dropdown, _get_font
 from systems.arena import (
     EloTracker, ArenaRunner, TournamentProgress, MatchResult,
-    write_tournament_summary,
+    write_tournament_summary, _format_match_desc,
 )
 
 # Colors
@@ -56,7 +56,7 @@ class _LogEntry:
                  "length_text", "avg_step_text",
                  "elo_delta_a", "elo_delta_b", "elo_color_a", "elo_color_b",
                  "finished", "replay_path", "error_log_path", "match_index",
-                 "status")
+                 "status", "participants", "matchup_text")
 
     def __init__(self):
         self.ai1_name: str = ""
@@ -76,6 +76,8 @@ class _LogEntry:
         self.error_log_path: str = ""
         self.match_index: int = -1
         self.status: str = "Queued"  # "Queued", "Running", "Done", "Error"
+        self.participants: list[tuple[str, int]] = []
+        self.matchup_text: str = ""  # pre-formatted display text
 
 
 class ArenaScreen(BaseScreen):
@@ -130,6 +132,11 @@ class ArenaScreen(BaseScreen):
         self._workers_slider = Slider(cx - 110, 0, 220, "Worker processes",
                                       1, 8, 4, 1)
 
+        # Format dropdown
+        self._format_choices = [("1v1", "1v1"), ("ffa", "FFA"), ("2v2", "2v2")]
+        self._format_dropdown = Dropdown(cx - 110, 0, 220,
+                                         self._format_choices, 0)
+
         # Buttons — positioned at bottom
         btn_y = self.height - 62
         btn_w = 160
@@ -162,6 +169,7 @@ class ArenaScreen(BaseScreen):
                 if not self._runner.running:
                     self._rounds_slider.handle_event(event)
                     self._workers_slider.handle_event(event)
+                    self._format_dropdown.handle_event(event)
 
                 if self._start_btn.handle_event(event):
                     if self._runner.running:
@@ -221,6 +229,12 @@ class ArenaScreen(BaseScreen):
             self._draw()
 
     def _start_tournament(self) -> None:
+        match_format = self._format_choices[self._format_dropdown.selected_index][0]
+
+        if match_format == "2v2" and len(self._ai_choices) < 4:
+            self._status_text = "Need at least 4 AIs for 2v2."
+            self._status_color = _STATUS_ERR
+            return
         if len(self._ai_choices) < 2:
             self._status_text = "Need at least 2 AIs for a tournament."
             self._status_color = _STATUS_ERR
@@ -242,6 +256,7 @@ class ArenaScreen(BaseScreen):
             ai_ids=ai_ids,
             rounds=self._rounds_slider.value,
             workers=self._workers_slider.value,
+            match_format=match_format,
         )
         self._start_btn.label = "Cancel"
         self._status_text = "Tournament in progress..."
@@ -251,12 +266,16 @@ class ArenaScreen(BaseScreen):
         self._progress = self._runner.poll()
 
         # Pre-populate log entries for all matchups
-        for idx, (ai1, ai2) in enumerate(self._progress.matchups):
+        for idx, parts in enumerate(self._progress.matchups):
             entry = _LogEntry()
-            entry.ai1_id = ai1
-            entry.ai2_id = ai2
-            entry.ai1_name = self._ai_names.get(ai1, ai1)
-            entry.ai2_name = self._ai_names.get(ai2, ai2)
+            entry.participants = list(parts)
+            entry.matchup_text = _format_match_desc(parts, self._ai_names)
+            # Keep ai1/ai2 for backward compat in filters
+            if len(parts) >= 2:
+                entry.ai1_id = parts[0][0]
+                entry.ai2_id = parts[1][0]
+                entry.ai1_name = self._ai_names.get(parts[0][0], parts[0][0])
+                entry.ai2_name = self._ai_names.get(parts[1][0], parts[1][0])
             entry.match_index = idx
             self._match_log.append(entry)
 
@@ -295,6 +314,10 @@ class ArenaScreen(BaseScreen):
 
     def _update_log_entry(self, entry: _LogEntry, mr: MatchResult) -> None:
         """Mutate an existing _LogEntry in-place when a result arrives."""
+        entry.participants = mr.participants or []
+        if mr.participants:
+            entry.matchup_text = _format_match_desc(mr.participants, self._ai_names)
+
         ai1_name = self._ai_names.get(mr.ai1_id, mr.ai1_id)
         ai2_name = self._ai_names.get(mr.ai2_id, mr.ai2_id)
         entry.ai1_name = ai1_name
@@ -305,12 +328,17 @@ class ArenaScreen(BaseScreen):
             entry.result_text = "Error"
             entry.result_color = _STATUS_ERR
             entry.status = "Error"
-        elif mr.winner == 1:
-            entry.result_text = f"{ai1_name} wins"
-            entry.result_color = _WIN_COLOR
+        elif mr.winner == -1:
+            entry.result_text = "Draw"
+            entry.result_color = _DRAW_COLOR
             entry.status = "Done"
-        elif mr.winner == 2:
-            entry.result_text = f"{ai2_name} wins"
+        elif mr.winner > 0:
+            winner_ids = [aid for aid, tid in mr.participants if tid == mr.winner] if mr.participants else []
+            if winner_ids:
+                winner_names = [self._ai_names.get(a, a) for a in winner_ids]
+                entry.result_text = ", ".join(winner_names) + " win" + ("s" if len(winner_names) == 1 else "")
+            else:
+                entry.result_text = f"Team {mr.winner} wins"
             entry.result_color = _WIN_COLOR
             entry.status = "Done"
         else:
@@ -327,8 +355,8 @@ class ArenaScreen(BaseScreen):
         # Avg step
         entry.avg_step_text = f"{mr.avg_step_ms:.1f}ms" if mr.avg_step_ms > 0 else "-"
 
-        # Elo delta
-        if mr.winner != 0:
+        # Elo delta (only for 1v1 — multi-player Elo is applied in bulk at tournament end)
+        if mr.winner != 0 and mr.match_format == "1v1":
             da, db = self._elo.compute_delta(
                 mr.ai1_id, mr.ai2_id, mr.winner,
                 ratings_snapshot=self._pre_ratings,
@@ -350,12 +378,20 @@ class ArenaScreen(BaseScreen):
         if self._progress is None:
             return
 
+        fmt = self._progress.match_format
         errors = 0
         for result in self._progress.results:
             if result.winner == 0:
                 errors += 1
                 continue
-            self._elo.update(result.ai1_id, result.ai2_id, result.winner)
+            if fmt == "ffa" and result.participants:
+                self._elo.update_ffa(
+                    result.participants, result.winner, result.contributions)
+            elif fmt == "2v2" and result.participants:
+                self._elo.update_2v2(
+                    result.participants, result.winner, result.contributions)
+            else:
+                self._elo.update(result.ai1_id, result.ai2_id, result.winner)
 
         self._elo.save()
         self._start_btn.label = "Start Tournament"
@@ -378,7 +414,9 @@ class ArenaScreen(BaseScreen):
         if not self._filter_bots:
             return self._match_log
         return [e for e in self._match_log
-                if e.ai1_id in self._filter_bots or e.ai2_id in self._filter_bots]
+                if any(aid in self._filter_bots
+                       for aid, _ in e.participants) or
+                e.ai1_id in self._filter_bots or e.ai2_id in self._filter_bots]
 
     # -- layout helpers --------------------------------------------------------
 
@@ -502,15 +540,26 @@ class ArenaScreen(BaseScreen):
                                         y + row_h // 2 - surf.get_height() // 2))
 
     def _draw_settings(self) -> None:
-        """Draw sliders in the middle area when no tournament has run."""
+        """Draw sliders and format dropdown in the middle area when no tournament has run."""
         log_top = self._log_top_y()
         cx = self.width // 2
         self._rounds_slider.x = cx - 110
         self._rounds_slider.y = log_top + 20
         self._workers_slider.x = cx - 110
         self._workers_slider.y = log_top + 70
+
+        # Format dropdown
+        self._format_dropdown.x = cx - 110
+        self._format_dropdown.y = log_top + 120
+
         self._rounds_slider.draw(self.screen)
         self._workers_slider.draw(self.screen)
+
+        # Label for format
+        font = _get_font(CONTENT_FONT_SIZE)
+        label = font.render("Format", True, CONTENT_TEXT)
+        self.screen.blit(label, (cx - 110, log_top + 105))
+        self._format_dropdown.draw(self.screen)
 
     def _draw_bot_filter(self, y: int) -> int:
         """Draw horizontal row of toggle pill chips. Returns new y below chips."""
@@ -521,8 +570,9 @@ class ArenaScreen(BaseScreen):
         bot_ids: list[str] = []
         seen: set[str] = set()
         for entry in self._match_log:
-            for bid in (entry.ai1_id, entry.ai2_id):
-                if bid not in seen:
+            ids = [aid for aid, _ in entry.participants] if entry.participants else [entry.ai1_id, entry.ai2_id]
+            for bid in ids:
+                if bid and bid not in seen:
                     seen.add(bid)
                     bot_ids.append(bid)
 
@@ -593,13 +643,16 @@ class ArenaScreen(BaseScreen):
         elif self._match_log:
             # Settings sliders above the log when tournament is done
             cx = self.width // 2
-            self._rounds_slider.x = cx - 110
+            self._rounds_slider.x = cx - 220
             self._rounds_slider.y = log_top
             self._workers_slider.x = cx + 10
             self._workers_slider.y = log_top
+            self._format_dropdown.x = cx - 220
+            self._format_dropdown.y = log_top + 32
             self._rounds_slider.draw(self.screen)
             self._workers_slider.draw(self.screen)
-            filter_y = log_top + 48
+            self._format_dropdown.draw(self.screen)
+            filter_y = log_top + 62
         else:
             filter_y = log_top
 
@@ -747,26 +800,35 @@ class ArenaScreen(BaseScreen):
                            x: int, y: int, row_h: int) -> None:
         """Render matchup with inline Elo deltas as multi-colored segments."""
         cy = y + row_h // 2
-        max_w = 300
+        max_w = int(self._table_w * 0.38)
         cursor = x
 
+        # For multi-team (FFA/2v2), use pre-formatted matchup text
+        if entry.participants and len(entry.participants) > 2:
+            text = entry.matchup_text or _format_match_desc(entry.participants, self._ai_names)
+            while font.size(text)[0] > max_w and len(text) > 5:
+                text = text[:-1]
+            if font.size(text)[0] > max_w:
+                text += ".."
+            surf = font.render(text, True, CONTENT_TEXT)
+            self.screen.blit(surf, (cursor, cy - surf.get_height() // 2))
+            return
+
+        # 1v1 with inline Elo deltas
         n1 = entry.ai1_name
         n2 = entry.ai2_name
 
         if entry.elo_delta_a is not None:
-            # Format: "Name1 (+16) vs Name2 (-16)"
             da_sign = "+" if entry.elo_delta_a >= 0 else ""
             db_sign = "+" if entry.elo_delta_b >= 0 else ""
             elo_a_str = f" ({da_sign}{entry.elo_delta_a:.0f})"
             elo_b_str = f" ({db_sign}{entry.elo_delta_b:.0f})"
             vs_str = " vs "
 
-            # Check if it fits
             total_w = (font.size(n1)[0] + font.size(elo_a_str)[0] +
                        font.size(vs_str)[0] + font.size(n2)[0] +
                        font.size(elo_b_str)[0])
             if total_w > max_w:
-                # Truncate names
                 avail = max_w - (font.size(elo_a_str)[0] +
                                  font.size(vs_str)[0] +
                                  font.size(elo_b_str)[0])
@@ -794,7 +856,6 @@ class ArenaScreen(BaseScreen):
                 (elo_b_str, entry.elo_color_b),
             ]
         else:
-            # No Elo yet — just "Name1 vs Name2"
             vs_str = " vs "
             total_w = font.size(n1)[0] + font.size(vs_str)[0] + font.size(n2)[0]
             if total_w > max_w:

--- a/screens/client_game.py
+++ b/screens/client_game.py
@@ -18,7 +18,7 @@ from config.settings import (
     CC_HP, METAL_EXTRACTOR_HP,
     METAL_SPOT_CAPTURE_ARC_WIDTH,
     SELECTED_COLOR, SELECTION_FILL_COLOR, SELECTION_RECT_COLOR,
-    TEAM1_COLOR, TEAM2_COLOR, TEAM_COLORS,
+    TEAM_COLORS, PLAYER_COLORS,
     CAMERA_ZOOM_STEP, CAMERA_MAX_ZOOM,
     EDGE_PAN_MARGIN, EDGE_PAN_SPEED,
     GUI_BORDER, GUI_BTN_SELECTED, GUI_BTN_HOVER, GUI_BTN_NORMAL,
@@ -31,6 +31,7 @@ from config.unit_types import UNIT_TYPES, get_spawnable_types
 from ui.widgets import _get_font, Slider, Button
 import gui
 from gui_adapter import wrap_entities
+from systems.replay import normalize_cp
 
 _STATUS_COLOR = (180, 180, 200)
 _DISCONNECT_COLOR = (255, 100, 100)
@@ -78,6 +79,7 @@ class ClientGameScreen(BaseScreen):
         self._client = client
         self._is_local = is_local
         self._my_team: int = client.client_team
+        self._all_teams: set[int] = set(client.player_team.values()) if client.player_team else {1, 2}
         mw = client.map_width
         mh = client.map_height
 
@@ -247,8 +249,9 @@ class ClientGameScreen(BaseScreen):
                 self._phase = "explode"
                 self._anim_timer = 0.0
                 # Build fragments from losing CCs
-                losing_team = 3 - self._winner if self._winner > 0 else 0
-                self._init_fragments(losing_team)
+                losing_teams = self._all_teams - {self._winner} if self._winner > 0 else set()
+                for _lt in losing_teams:
+                    self._init_fragments(_lt)
 
             # Update explosion fragments
             if self._phase == "explode":
@@ -609,17 +612,23 @@ class ClientGameScreen(BaseScreen):
 
     def _build_result(self) -> ScreenResult:
         self._client.stop()
-        # Use opponent name from lobby_status if available, else fall back to host_name
-        opponent_name = self._client.opponent_name or self._client.host_name
+        # Build team_names from player_names / player_team, supporting N teams
+        team_names: dict[int, str] = {}
+        if self._player_names and self._client.player_team:
+            for pid, pname in self._player_names.items():
+                tm = self._client.player_team.get(pid, pid)
+                team_names[tm] = pname
+        if not team_names:
+            team_names[self._my_team] = self._client._player_name
+            opponent_name = self._client.opponent_name or self._client.host_name
+            for t in self._all_teams - {self._my_team}:
+                team_names[t] = opponent_name
         return ScreenResult("results", data={
             "winner": self._winner,
             "human_teams": {self._my_team},
             "stats": None,
             "replay_filepath": "",
-            "team_names": {
-                self._my_team: self._client._player_name,
-                3 - self._my_team: opponent_name,
-            },
+            "team_names": team_names,
         })
 
     # -- display click (group grid → center camera) --------------------------
@@ -733,7 +742,7 @@ class ClientGameScreen(BaseScreen):
             if pts:
                 scaled = [(cx + px * scale, cy + py * scale) for px, py in pts]
                 pygame.draw.polygon(ws, color, scaled)
-                outline = (150, 220, 255) if tm == 1 else (255, 140, 140)
+                outline = TEAM_COLORS.get(tm, PLAYER_COLORS[0])
                 pygame.draw.polygon(ws, outline, scaled, 2)
 
             # Glow ring
@@ -909,7 +918,7 @@ class ClientGameScreen(BaseScreen):
         font = _get_font(22)
 
         # Team indicator
-        team_color = TEAM1_COLOR if self._my_team == 1 else TEAM2_COLOR
+        team_color = TEAM_COLORS.get(self._my_team, PLAYER_COLORS[0])
         team_label = font.render(f"Team {self._my_team}", True, team_color)
         self.screen.blit(team_label, (10, 10))
 
@@ -1144,7 +1153,7 @@ class ClientGameScreen(BaseScreen):
         if pts:
             translated = [(x + px, y + py) for px, py in pts]
             pygame.draw.polygon(ws, c, translated)
-            outline = (150, 220, 255) if tm == 1 else (255, 140, 140)
+            outline = TEAM_COLORS.get(tm, PLAYER_COLORS[0])
             pygame.draw.polygon(ws, outline, translated, 2)
 
         # Spawn progress arc
@@ -1187,26 +1196,24 @@ class ClientGameScreen(BaseScreen):
 
         if ow is None:
             color = (255, 200, 60)
-        elif ow == 1:
-            color = (80, 140, 255)
         else:
-            color = (255, 80, 80)
+            color = TEAM_COLORS.get(ow, PLAYER_COLORS[0])
         pygame.draw.circle(ws, color, (int(x), int(y)), int(r))
 
-        if ow is None and abs(cp) > 0.01:
-            progress_color = (TEAM_COLORS.get(1, (80, 140, 255)) if cp > 0
-                              else TEAM_COLORS.get(2, (255, 80, 80)))
+        cp_dict = normalize_cp(cp)
+        if ow is None and cp_dict:
             arc_r = METAL_SPOT_CAPTURE_RADIUS + METAL_SPOT_CAPTURE_ARC_WIDTH
-            start_angle = math.pi / 2
-            end_angle = start_angle + cp * math.tau
-            if cp > 0:
-                a, b = start_angle, end_angle
-            else:
-                a, b = end_angle, start_angle
             rect = pygame.Rect(int(x - arc_r), int(y - arc_r),
                                int(arc_r * 2), int(arc_r * 2))
-            pygame.draw.arc(ws, progress_color, rect, a, b,
-                            int(METAL_SPOT_CAPTURE_ARC_WIDTH))
+            start_angle = math.pi / 2
+            for team_id, progress in cp_dict.items():
+                if progress < 0.01:
+                    continue
+                progress_color = TEAM_COLORS.get(team_id, PLAYER_COLORS[0])
+                end_angle = start_angle + progress * math.tau
+                pygame.draw.arc(ws, progress_color, rect,
+                                start_angle, end_angle,
+                                int(METAL_SPOT_CAPTURE_ARC_WIDTH))
 
     def _draw_metal_extractor(self, ent: dict) -> None:
         ws = self._world_surface
@@ -1229,7 +1236,7 @@ class ClientGameScreen(BaseScreen):
         # Reinforcement plating arcs
         rst = ent.get("rst", 0)
         if rst > 0:
-            arc_color = TEAM_COLORS.get(tm, TEAM1_COLOR)
+            arc_color = TEAM_COLORS.get(tm, PLAYER_COLORS[0])
             arc_r = METAL_SPOT_CAPTURE_RADIUS
             rect = pygame.Rect(x - arc_r, y - arc_r, arc_r * 2, arc_r * 2)
             arc_span = math.radians(87.5)
@@ -1288,10 +1295,10 @@ class ClientGameScreen(BaseScreen):
                 tm = pt.get(pid, pid)
                 names[tm] = pname
         if not names:
-            names = {
-                self._my_team: self._client._player_name,
-                3 - self._my_team: self._client.opponent_name or self._client.host_name,
-            }
+            names[self._my_team] = self._client._player_name
+            opponent_name = self._client.opponent_name or self._client.host_name
+            for t in self._all_teams - {self._my_team}:
+                names[t] = opponent_name
         for ent in entities:
             if ent.get("t") != "CC":
                 continue
@@ -1301,7 +1308,7 @@ class ClientGameScreen(BaseScreen):
             bp = ent.get("bp", 0)
             if bp > 0:
                 name = f"{name} (+{bp}%)"
-            team_color = TEAM1_COLOR if tm == 1 else TEAM2_COLOR
+            team_color = TEAM_COLORS.get(tm, PLAYER_COLORS[0])
             name_surf = font.render(name, True, team_color)
             nx = int(ent.get("x", 0)) - name_surf.get_width() // 2
             ny = int(ent.get("y", 0)) - 40

--- a/screens/create_lobby.py
+++ b/screens/create_lobby.py
@@ -61,7 +61,7 @@ _PANEL_BORDER = (42, 42, 62)
 _HDR_COLOR    = (160, 160, 185)   # subdued column-header colour
 _DIVIDER_CLR  = (35, 35, 52)
 
-_TEAM_CHOICES = [("1", "Team 1"), ("2", "Team 2")]
+_TEAM_CHOICES = [(str(i), f"Team {i}") for i in range(1, 9)]
 
 # Vertical layout constants (relative to top of screen)
 _TITLE_Y      = 16
@@ -207,7 +207,7 @@ class CreateLobbyScreen(BaseScreen):
                    color_idx: int = -1, name: str = "") -> _Slot:
         y = self._slot_y(idx)
         ai_idx = self._find_ai_index(ai_id, self._full_choices, 0)
-        team_idx = 0 if team_id == 1 else 1
+        team_idx = max(0, team_id - 1)
         ai_dd = Dropdown(self._ai_dd_x, y, _AI_DD_W, self._full_choices, ai_idx)
         team_dd = Dropdown(self._team_dd_x, y, _TEAM_DD_W, _TEAM_CHOICES, team_idx)
         remove_btn = Button(

--- a/screens/multiplayer_lobby.py
+++ b/screens/multiplayer_lobby.py
@@ -8,7 +8,7 @@ from ui.theme import (
     MENU_BG, CONTENT_TEXT, HEADING_FONT_SIZE, CONTENT_FONT_SIZE,
     BTN_WIDTH, BTN_HEIGHT,
 )
-from ui.widgets import Button, BackButton, TextInput, ToggleGroup, Slider, _get_font
+from ui.widgets import Button, BackButton, TextInput, ToggleGroup, Slider, Dropdown, _get_font
 from networking.protocol import DEFAULT_PORT
 from screens.create_lobby import _load_settings
 
@@ -88,6 +88,10 @@ class MultiplayerLobbyScreen(BaseScreen):
         self._host_obstacles = Slider(
             cx - 110, 290, 220, "Obstacles", 0, 20, 0, 1,
         )
+        self._host_team_choices = [(str(i), f"Team {i}") for i in range(1, 9)]
+        self._host_team_dropdown = Dropdown(
+            cx - 110, 330, 220, self._host_team_choices, 0,
+        )
         self._host_start_btn = Button(
             cx - BTN_WIDTH // 2, self.height - 80,
             BTN_WIDTH, BTN_HEIGHT, "Start Game",
@@ -95,7 +99,7 @@ class MultiplayerLobbyScreen(BaseScreen):
         self._host_obj = None
         self._host_status = "Waiting for player..."
         self._copy_ip_btn = Button(
-            cx - 45, 400, 90, 30, "Copy IP", font_size=18,
+            cx - 45, 410, 90, 30, "Copy IP", font_size=18,
         )
         self._copy_flash: float = 0.0  # seconds remaining for "Copied!" feedback
 
@@ -168,6 +172,7 @@ class MultiplayerLobbyScreen(BaseScreen):
                     self._host_name_input.handle_event(event)
                     self._host_map_size.handle_event(event)
                     self._host_obstacles.handle_event(event)
+                    self._host_team_dropdown.handle_event(event)
                     if self._copy_ip_btn.handle_event(event):
                         if self._host_obj:
                             self._copy_to_clipboard(self._host_obj.local_ip)
@@ -298,6 +303,10 @@ class MultiplayerLobbyScreen(BaseScreen):
         map_w, map_h = _MAP_SIZES[map_key]
         obs_val = self._host_obstacles.value
         host_name = self._host_name_input.text.strip() or "Host"
+        host_team = int(self._host_team_dropdown.value)
+        # Assign client to a different team (next team cyclically)
+        client_team = (host_team % 8) + 1 if host_team < 8 else 1
+        player_team = {1: host_team, 2: client_team}
         return ScreenResult("mp_host_game", data={
             "host": self._host_obj,
             "host_name": host_name,
@@ -305,6 +314,7 @@ class MultiplayerLobbyScreen(BaseScreen):
             "width": map_w,
             "height": map_h,
             "obstacle_count": (obs_val, obs_val),
+            "player_team": player_team,
         })
 
     def _build_join_result(self) -> ScreenResult:
@@ -367,18 +377,22 @@ class MultiplayerLobbyScreen(BaseScreen):
             self._host_map_size.draw(self.screen)
             self._host_obstacles.draw(self.screen)
 
+            team_label = font.render("Your Team:", True, CONTENT_TEXT)
+            self.screen.blit(team_label, (cx - 110, 318))
+            self._host_team_dropdown.draw(self.screen)
+
             # Status
             ready = self._host_obj and self._host_obj.client_ready
             color = _SUCCESS_COLOR if ready else _STATUS_COLOR
             status = font.render(self._host_status, True, color)
-            self.screen.blit(status, (cx - status.get_width() // 2, 370))
+            self.screen.blit(status, (cx - status.get_width() // 2, 380))
 
             # Copy IP button
             if self._host_obj:
                 self._copy_ip_btn.draw(self.screen)
                 if self._copy_flash > 0:
                     copied = font.render("Copied!", True, _SUCCESS_COLOR)
-                    self.screen.blit(copied, (cx - copied.get_width() // 2, 435))
+                    self.screen.blit(copied, (cx - copied.get_width() // 2, 445))
 
             if ready:
                 self._host_start_btn.draw(self.screen)

--- a/screens/replay_playback.py
+++ b/screens/replay_playback.py
@@ -6,9 +6,8 @@ from screens.base import BaseScreen, ScreenResult
 from screens.results import (_draw_3d_bar, _ease_out_cubic,
                               _compress_build_order, _build_order_label,
                               _PLAYER_COLORS as _RES_PLAYER_COLORS,
-                              _BAR_T1_COLOR, _BAR_T2_COLOR, _BAR_BORDER_T1, _BAR_BORDER_T2,
                               _BAR_HEIGHT, _BAR_PAD_X, _BAR_GAP, _ANIM_MS)
-from systems.replay import ReplayReader
+from systems.replay import ReplayReader, normalize_cp
 from config.settings import (
     OBSTACLE_OUTLINE, HEALTH_BAR_WIDTH, HEALTH_BAR_HEIGHT,
     HEALTH_BAR_BG, HEALTH_BAR_FG, HEALTH_BAR_LOW, HEALTH_BAR_OFFSET,
@@ -18,7 +17,7 @@ from config.settings import (
     METAL_SPOT_CAPTURE_ARC_WIDTH,
     METAL_EXTRACTOR_SPAWN_BONUS,
     SELECTED_COLOR, SELECTION_FILL_COLOR, SELECTION_RECT_COLOR,
-    TEAM1_COLOR, TEAM2_COLOR, TEAM_COLORS, RANGE_COLOR, MEDIC_HEAL_COLOR,
+    TEAM_COLORS, PLAYER_COLORS, RANGE_COLOR, MEDIC_HEAL_COLOR,
     CC_LASER_RANGE,
     CAMERA_ZOOM_STEP, CAMERA_MAX_ZOOM,
 )
@@ -26,8 +25,8 @@ from core.camera import Camera
 from config.unit_types import UNIT_TYPES
 from ui.widgets import Slider, Button, ToggleGroup, LineGraph, _get_font
 from ui.theme import (
-    MENU_BG, GRAPH_LINE_T1, GRAPH_LINE_T2,
-    SCORE_FONT_SIZE, SCORE_T1_COLOR, SCORE_T2_COLOR,
+    MENU_BG, GRAPH_LINE_COLORS,
+    SCORE_FONT_SIZE, SCORE_TEAM_COLORS,
     STATS_HEADER_FONT_SIZE, STATS_SUB_FONT_SIZE,
     BUILD_ORDER_RADIUS,
 )
@@ -153,8 +152,11 @@ class ReplayPlaybackScreen(BaseScreen):
             names = [self._player_names.get(p, f"P{p}") for p in sorted(pids)]
             self._team_names[tid] = " & ".join(names) if names else f"Team {tid}"
 
-        self._name1 = self._team_names.get(1, "Team 1")
-        self._name2 = self._team_names.get(2, "Team 2")
+        # Build ordered list of (team_id, label) for team view cycling
+        # Index 0 = "All Teams", then one entry per team sorted by team_id
+        self._team_view_options: list[tuple[int, str]] = [(0, "All Teams")]
+        for tid, name in sorted(self._team_names.items()):
+            self._team_view_options.append((tid, name))
 
         self._playing = True
         self._ended = False
@@ -248,7 +250,10 @@ class ReplayPlaybackScreen(BaseScreen):
             self._stat_tabs = ToggleGroup(tab_x, 80, _STAT_TABS,
                                           selected_index=0, btn_w=tab_w, btn_h=28)
             self._stat_graph = LineGraph(30, 115, sw - 60, sh - 200,
-                                         color1=GRAPH_LINE_T1, color2=GRAPH_LINE_T2)
+                                         color1=GRAPH_LINE_COLORS[0],
+                                         color2=GRAPH_LINE_COLORS[1]
+                                              if len(GRAPH_LINE_COLORS) > 1
+                                              else GRAPH_LINE_COLORS[0])
             has_subsystem = "subsystem_ms" in (self._stats_data or {})
             btn_w = 120
             gap = 10
@@ -277,18 +282,27 @@ class ReplayPlaybackScreen(BaseScreen):
         key = self._stat_tabs.value
         if key == "build_order":
             return  # build order tab doesn't use graph
-        if key == "step_ms":
-            t1 = self._stats_data.get("step_ms", [])
-            t2 = []
-        else:
-            t1 = self._stats_data.get("teams", {}).get("1", {}).get(key, [])
-            t2 = self._stats_data.get("teams", {}).get("2", {}).get(key, [])
 
-        # Convert metal spots to build % bonus
-        if key == "metal_spots":
-            bonus_pct = METAL_EXTRACTOR_SPAWN_BONUS * 100  # 8
-            t1 = [v * bonus_pct for v in t1]
-            t2 = [v * bonus_pct for v in t2]
+        teams_data = self._stats_data.get("teams", {})
+
+        if key == "step_ms":
+            # step_ms is global, not per-team
+            series = [(self._stats_data.get("step_ms", []),
+                        GRAPH_LINE_COLORS[0], "Step ms")]
+        else:
+            # Build one series per team, sorted by team key
+            series: list[tuple[list[float], tuple, str]] = []
+            for team_key in sorted(teams_data.keys(), key=lambda k: int(k)):
+                tid = int(team_key)
+                data = teams_data[team_key].get(key, [])
+                # Convert metal spots to build % bonus
+                if key == "metal_spots":
+                    bonus_pct = METAL_EXTRACTOR_SPAWN_BONUS * 100  # 8
+                    data = [v * bonus_pct for v in data]
+                color_idx = tid - 1
+                color = GRAPH_LINE_COLORS[color_idx % len(GRAPH_LINE_COLORS)]
+                label = self._team_names.get(tid, f"Team {tid}")
+                series.append((data, color, label))
 
         timestamps = self._stats_data.get("timestamps", [])
         x_labels = []
@@ -305,7 +319,7 @@ class ReplayPlaybackScreen(BaseScreen):
         self._stat_graph.y_tick_step = 8.0 if key == "metal_spots" else None
         self._stat_graph.y_integer_ticks = key in ("army_count", "units_killed")
 
-        self._stat_graph.set_data(t1, t2, x_labels, timestamps=timestamps)
+        self._stat_graph.set_series(series, x_labels, timestamps=timestamps)
 
     def _is_build_tab(self) -> bool:
         return self._stats_data is not None and self._stat_tabs.value == "build_order"
@@ -421,9 +435,10 @@ class ReplayPlaybackScreen(BaseScreen):
                     continue
 
                 if self._team_view_btn.handle_event(event):
-                    self._team_view = (self._team_view + 1) % 3
-                    _TV_LABELS = ["All Teams", self._name1, self._name2]
-                    self._team_view_btn.label = _TV_LABELS[self._team_view]
+                    n_opts = len(self._team_view_options)
+                    self._team_view = (self._team_view + 1) % n_opts
+                    tid, label = self._team_view_options[self._team_view]
+                    self._team_view_btn.label = label
                     self._selected_ids.clear()
                     continue
 
@@ -687,17 +702,22 @@ class ReplayPlaybackScreen(BaseScreen):
                 break
         return idx
 
-    def _get_latest_stat_values(self, key: str) -> tuple[float, float]:
-        """Get the time-series value for a stat key at the current replay time."""
+    def _get_latest_stat_values(self, key: str) -> dict[int, float]:
+        """Get the time-series value for a stat key at the current replay time.
+
+        Returns a dict mapping team_id -> value for all teams in the data.
+        """
         if not self._stats_data:
-            return 0.0, 0.0
+            return {}
         idx = self._get_stat_index()
         teams = self._stats_data.get("teams", {})
-        t1_list = teams.get("1", {}).get(key, [])
-        t2_list = teams.get("2", {}).get(key, [])
-        v1 = t1_list[idx] if idx < len(t1_list) else (t1_list[-1] if t1_list else 0.0)
-        v2 = t2_list[idx] if idx < len(t2_list) else (t2_list[-1] if t2_list else 0.0)
-        return float(v1), float(v2)
+        result: dict[int, float] = {}
+        for team_key in sorted(teams.keys(), key=lambda k: int(k)):
+            tid = int(team_key)
+            data_list = teams[team_key].get(key, [])
+            val = data_list[idx] if idx < len(data_list) else (data_list[-1] if data_list else 0.0)
+            result[tid] = float(val)
+        return result
 
     def _handle_stat_dropdown_event(self, event: pygame.event.Event) -> bool:
         """Handle arrow button events for single-stat mode (mode 2)."""
@@ -712,22 +732,25 @@ class ReplayPlaybackScreen(BaseScreen):
         return False
 
     def _draw_comparison_bar(self, x: int, y: int, w: int, h: int,
-                             v1: float, v2: float):
-        """Draw a horizontal bar split proportionally between T1 and T2."""
-        total = v1 + v2
+                             values: dict[int, float]):
+        """Draw a horizontal bar split proportionally among N teams."""
+        total = sum(values.values())
         if total <= 0:
-            # Both zero — gray 50/50
             pygame.draw.rect(self.screen, (60, 60, 70), (x, y, w, h),
                              border_radius=2)
         else:
-            t1_w = max(1, int(w * v1 / total))
-            t2_w = w - t1_w
-            if t1_w > 0:
-                pygame.draw.rect(self.screen, GRAPH_LINE_T1,
-                                 (x, y, t1_w, h), border_radius=2)
-            if t2_w > 0:
-                pygame.draw.rect(self.screen, GRAPH_LINE_T2,
-                                 (x + t1_w, y, t2_w, h), border_radius=2)
+            cx = x
+            sorted_tids = sorted(values.keys())
+            for i, tid in enumerate(sorted_tids):
+                frac = values[tid] / total
+                is_last = (i == len(sorted_tids) - 1)
+                seg_w = (w - (cx - x)) if is_last else max(1, int(w * frac))
+                if seg_w > 0:
+                    color_idx = tid - 1
+                    color = GRAPH_LINE_COLORS[color_idx % len(GRAPH_LINE_COLORS)]
+                    pygame.draw.rect(self.screen, color,
+                                     (cx, y, seg_w, h), border_radius=2)
+                cx += seg_w
 
     def _draw_stat_text(self, text: str, font, color: tuple, x: int, y: int):
         """Draw text with a dark shadow for readability against the game."""
@@ -756,26 +779,40 @@ class ReplayPlaybackScreen(BaseScreen):
             row_h = 22
             for i, (key, label) in enumerate(_DROPDOWN_STATS):
                 ry = py + i * row_h
-                v1, v2 = self._get_latest_stat_values(key)
+                values = self._get_latest_stat_values(key)
 
                 self._draw_stat_text(label, font, (180, 180, 200), px + 6, ry + 2)
 
                 bar_x = px + 70
                 bar_w = pw - 76
-                self._draw_comparison_bar(bar_x, ry + 3, bar_w, 8, v1, v2)
+                self._draw_comparison_bar(bar_x, ry + 3, bar_w, 8, values)
 
-                v1_str = _fmt_stat(key, v1)
-                v2_str = _fmt_stat(key, v2)
-                self._draw_stat_text(v1_str, val_font, GRAPH_LINE_T1,
-                                     bar_x, ry + 12)
-                v2s = val_font.render(v2_str, True, GRAPH_LINE_T2)
-                self._draw_stat_text(v2_str, val_font, GRAPH_LINE_T2,
-                                     bar_x + bar_w - v2s.get_width(), ry + 12)
+                # Draw per-team value labels below the bar
+                sorted_tids = sorted(values.keys())
+                n_teams = len(sorted_tids)
+                for j, tid in enumerate(sorted_tids):
+                    v_str = _fmt_stat(key, values[tid])
+                    color_idx = tid - 1
+                    color = GRAPH_LINE_COLORS[color_idx % len(GRAPH_LINE_COLORS)]
+                    if n_teams <= 2:
+                        # Classic layout: first left-aligned, last right-aligned
+                        if j == 0:
+                            self._draw_stat_text(v_str, val_font, color,
+                                                 bar_x, ry + 12)
+                        else:
+                            vs = val_font.render(v_str, True, color)
+                            self._draw_stat_text(v_str, val_font, color,
+                                                 bar_x + bar_w - vs.get_width(), ry + 12)
+                    else:
+                        # Evenly spaced for 3+ teams
+                        seg = bar_w // n_teams
+                        self._draw_stat_text(v_str, val_font, color,
+                                             bar_x + j * seg, ry + 12)
 
         elif self._stat_mode == 2:
             # Single-stat view with arrows (no background)
             key, label = _DROPDOWN_STATS[self._stat_dropdown_idx]
-            v1, v2 = self._get_latest_stat_values(key)
+            values = self._get_latest_stat_values(key)
 
             lbl = font.render(label, True, (200, 200, 220))
             lbl_x = px + pw // 2 - lbl.get_width() // 2
@@ -784,16 +821,27 @@ class ReplayPlaybackScreen(BaseScreen):
             bar_x = px + 28
             bar_w = pw - 56
             bar_y = py + 24
-            self._draw_comparison_bar(bar_x, bar_y, bar_w, 10, v1, v2)
+            self._draw_comparison_bar(bar_x, bar_y, bar_w, 10, values)
 
-            v1_str = _fmt_stat(key, v1)
-            v2_str = _fmt_stat(key, v2)
-            v1s = val_font.render(v1_str, True, GRAPH_LINE_T1)
-            v2s = val_font.render(v2_str, True, GRAPH_LINE_T2)
-            self._draw_stat_text(v1_str, val_font, GRAPH_LINE_T1,
-                                 bar_x, bar_y + 14)
-            self._draw_stat_text(v2_str, val_font, GRAPH_LINE_T2,
-                                 bar_x + bar_w - v2s.get_width(), bar_y + 14)
+            # Draw per-team value labels below the bar
+            sorted_tids = sorted(values.keys())
+            n_teams = len(sorted_tids)
+            for j, tid in enumerate(sorted_tids):
+                v_str = _fmt_stat(key, values[tid])
+                color_idx = tid - 1
+                color = GRAPH_LINE_COLORS[color_idx % len(GRAPH_LINE_COLORS)]
+                if n_teams <= 2:
+                    if j == 0:
+                        self._draw_stat_text(v_str, val_font, color,
+                                             bar_x, bar_y + 14)
+                    else:
+                        vs = val_font.render(v_str, True, color)
+                        self._draw_stat_text(v_str, val_font, color,
+                                             bar_x + bar_w - vs.get_width(), bar_y + 14)
+                else:
+                    seg = bar_w // n_teams
+                    self._draw_stat_text(v_str, val_font, color,
+                                         bar_x + j * seg, bar_y + 14)
 
             # Arrow buttons on sides
             self._dd_left_btn.rect.topleft = (px + 4, py + 24)
@@ -826,41 +874,45 @@ class ReplayPlaybackScreen(BaseScreen):
         dur_surf = sub_font.render(dur_str, True, (160, 160, 180))
         self.screen.blit(dur_surf, (mw - dur_surf.get_width() - 15, 15))
 
-        # Animated score bars
+        # Animated score bars — N-team proportional
         if self._stats_data and "final" in self._stats_data:
             final = self._stats_data["final"]
-            s1 = final.get("1", {}).get("score", 0)
-            s2 = final.get("2", {}).get("score", 0)
-            total_score = s1 + s2
 
+            # Collect scores for all teams
+            team_scores: list[tuple[int, int]] = []  # (team_id, score)
+            for team_key in sorted(final.keys(), key=lambda k: int(k)):
+                tid = int(team_key)
+                score = final[team_key].get("score", 0)
+                team_scores.append((tid, score))
+
+            total_score = sum(s for _, s in team_scores)
             elapsed = pygame.time.get_ticks() - self._score_anim_start
             progress = _ease_out_cubic(min(1.0, elapsed / _ANIM_MS))
 
             bar_y = 38
-            bar_area = mw - _BAR_PAD_X * 2 - _BAR_GAP
-            frac1 = s1 / total_score if total_score > 0 else 0.5
-            w1 = int(bar_area * frac1 * progress)
-            w2 = int(bar_area * (1.0 - frac1) * progress)
-
-            r1 = pygame.Rect(_BAR_PAD_X, bar_y, w1, _BAR_HEIGHT)
-            _draw_3d_bar(self.screen, r1, _BAR_T1_COLOR, _BAR_BORDER_T1)
-
-            r2_x = mw - _BAR_PAD_X - w2
-            r2 = pygame.Rect(r2_x, bar_y, w2, _BAR_HEIGHT)
-            _draw_3d_bar(self.screen, r2, _BAR_T2_COLOR, _BAR_BORDER_T2)
-
+            n_teams = len(team_scores)
+            bar_area = mw - _BAR_PAD_X * 2 - _BAR_GAP * max(0, n_teams - 1)
             score_font = _get_font(SCORE_FONT_SIZE)
-            s1_surf = score_font.render(f"{self._name1}: {s1:,}", True, (255, 255, 255))
-            s2_surf = score_font.render(f"{self._name2}: {s2:,}", True, (255, 255, 255))
 
-            s1_y = bar_y + (_BAR_HEIGHT - s1_surf.get_height()) // 2
-            if progress > 0.05:
-                self.screen.blit(s1_surf, (_BAR_PAD_X + 10, s1_y))
+            bx = _BAR_PAD_X
+            for i, (tid, score) in enumerate(team_scores):
+                frac = score / total_score if total_score > 0 else 1.0 / max(n_teams, 1)
+                seg_w = int(bar_area * frac * progress)
 
-            s2_y = bar_y + (_BAR_HEIGHT - s2_surf.get_height()) // 2
-            if progress > 0.05:
-                self.screen.blit(s2_surf,
-                                 (mw - _BAR_PAD_X - s2_surf.get_width() - 10, s2_y))
+                color_idx = tid - 1
+                bar_color = SCORE_TEAM_COLORS[color_idx % len(SCORE_TEAM_COLORS)]
+                border_color = tuple(min(c + 30, 255) for c in bar_color[:3])
+
+                r = pygame.Rect(bx, bar_y, seg_w, _BAR_HEIGHT)
+                _draw_3d_bar(self.screen, r, bar_color, border_color)
+
+                team_name = self._team_names.get(tid, f"Team {tid}")
+                s_surf = score_font.render(f"{team_name}: {score:,}", True, (255, 255, 255))
+                s_y = bar_y + (_BAR_HEIGHT - s_surf.get_height()) // 2
+                if progress > 0.05 and seg_w > 10:
+                    self.screen.blit(s_surf, (bx + 10, s_y))
+
+                bx += seg_w + _BAR_GAP
 
         self._stat_tabs.draw(self.screen)
 
@@ -959,7 +1011,8 @@ class ReplayPlaybackScreen(BaseScreen):
             return False
         if self._team_view == 0:
             return True
-        return ent.get("tm") == self._team_view
+        viewed_tid = self._team_view_options[self._team_view][0]
+        return ent.get("tm") == viewed_tid
 
     def _click_select(self, entities: list[dict], mx: float, my: float,
                       additive: bool):
@@ -1105,6 +1158,8 @@ class ReplayPlaybackScreen(BaseScreen):
         if self._team_view == 0:
             return
 
+        viewed_tid = self._team_view_options[self._team_view][0]
+
         FOG_ALPHA = 200
         self._fog_surface.fill((0, 0, 0, FOG_ALPHA))
 
@@ -1114,7 +1169,7 @@ class ReplayPlaybackScreen(BaseScreen):
             t = ent.get("t")
             if t not in ("U", "CC", "ME"):
                 continue
-            if ent.get("tm") != self._team_view:
+            if ent.get("tm") != viewed_tid:
                 continue
             ut = ent.get("ut", "soldier")
             stats = UNIT_TYPES.get(ut, {})
@@ -1153,7 +1208,7 @@ class ReplayPlaybackScreen(BaseScreen):
                 continue
             tm = ent.get("tm", 1)
             name = self._team_names.get(tm, f"Team {tm}")
-            team_color = TEAM1_COLOR if tm == 1 else TEAM2_COLOR
+            team_color = TEAM_COLORS.get(tm, PLAYER_COLORS[0])
             name_surf = font.render(name, True, team_color)
             nx = int(ent.get("x", 0)) - name_surf.get_width() // 2
             ny = int(ent.get("y", 0)) - 40
@@ -1232,7 +1287,8 @@ class ReplayPlaybackScreen(BaseScreen):
         if pts:
             translated = [(x + px, y + py) for px, py in pts]
             pygame.draw.polygon(ws, c, translated)
-            outline = (150, 220, 255) if tm == 1 else (255, 140, 140)
+            tc = TEAM_COLORS.get(tm, PLAYER_COLORS[0])
+            outline = tuple(min(c + 70, 255) for c in tc[:3])
             pygame.draw.polygon(ws, outline, translated, 2)
 
         if hp < CC_HP:
@@ -1244,7 +1300,7 @@ class ReplayPlaybackScreen(BaseScreen):
         x, y = ent.get("x", 0), ent.get("y", 0)
         r = ent.get("r", 5)
         ow = ent.get("ow")
-        cp = ent.get("cp", 0.0)
+        raw_cp = ent.get("cp", 0.0)
 
         # Capture range circle with alpha
         cr = int(METAL_SPOT_CAPTURE_RADIUS)
@@ -1253,29 +1309,28 @@ class ReplayPlaybackScreen(BaseScreen):
         pygame.draw.circle(temp, METAL_SPOT_CAPTURE_RANGE_COLOR, (cr, cr), cr)
         ws.blit(temp, (int(x) - cr, int(y) - cr))
 
-        # Base dot
+        # Base dot — color by owner team
         if ow is None:
             color = (255, 200, 60)
-        elif ow == 1:
-            color = (80, 140, 255)
         else:
-            color = (255, 80, 80)
+            color = TEAM_COLORS.get(ow, PLAYER_COLORS[0])
         pygame.draw.circle(ws, color, (int(x), int(y)), int(r))
 
-        # Capture progress arc
-        if ow is None and abs(cp) > 0.01:
-            progress_color = TEAM_COLORS.get(1, (80, 140, 255)) if cp > 0 else TEAM_COLORS.get(2, (255, 80, 80))
+        # Capture progress arcs — one per team with progress
+        cp_dict = normalize_cp(raw_cp)
+        if ow is None and cp_dict:
             arc_r = METAL_SPOT_CAPTURE_RADIUS + METAL_SPOT_CAPTURE_ARC_WIDTH
-            start_angle = math.pi / 2
-            end_angle = start_angle + cp * math.tau
-            if cp > 0:
-                a, b = start_angle, end_angle
-            else:
-                a, b = end_angle, start_angle
             rect = pygame.Rect(int(x - arc_r), int(y - arc_r),
                                int(arc_r * 2), int(arc_r * 2))
-            pygame.draw.arc(ws, progress_color, rect, a, b,
-                            int(METAL_SPOT_CAPTURE_ARC_WIDTH))
+            for tid, progress in sorted(cp_dict.items()):
+                if progress < 0.01:
+                    continue
+                progress_color = TEAM_COLORS.get(tid, PLAYER_COLORS[0])
+                start_angle = math.pi / 2
+                end_angle = start_angle + progress * math.tau
+                pygame.draw.arc(ws, progress_color, rect,
+                                start_angle, end_angle,
+                                int(METAL_SPOT_CAPTURE_ARC_WIDTH))
 
     def _draw_metal_extractor(self, ent: dict):
         ws = self._world_surface

--- a/screens/results.py
+++ b/screens/results.py
@@ -4,14 +4,14 @@ import pygame
 from screens.base import BaseScreen, ScreenResult
 from ui.theme import (
     MENU_BG, BTN_WIDTH, BTN_HEIGHT,
-    GRAPH_LINE_T1, GRAPH_LINE_T2,
-    SCORE_FONT_SIZE, SCORE_T1_COLOR, SCORE_T2_COLOR,
+    GRAPH_LINE_COLORS, GRAPH_FILL_COLORS, SCORE_TEAM_COLORS,
+    SCORE_FONT_SIZE,
     STATS_HEADER_FONT_SIZE, STATS_SUB_FONT_SIZE,
     BUILD_ORDER_RADIUS,
 )
-from ui.widgets import Button, ToggleGroup, LineGraph, _get_font
+from ui.widgets import Button, ToggleGroup, MultiLineGraph, _get_font
 from config.unit_types import UNIT_TYPES
-from config.settings import METAL_EXTRACTOR_SPAWN_BONUS
+from config.settings import METAL_EXTRACTOR_SPAWN_BONUS, TEAM_COLORS
 
 # Player colour dots (matches lobby palette)
 _PLAYER_COLORS = [
@@ -38,21 +38,25 @@ _WHITE = (220, 220, 240)
 # Score bar animation
 _BAR_PAD_X = 30
 _BAR_GAP = 4
-_BAR_HEIGHT = 36
+_BAR_HEIGHT = 28
 _BAR_Y = 48
 _ANIM_MS = 3000
-_BAR_T1_COLOR = (60, 130, 255)
-_BAR_T2_COLOR = (235, 65, 65)
-_BAR_BORDER_T1 = (90, 160, 255)
-_BAR_BORDER_T2 = (255, 100, 100)
+
+
+def _bar_color(team_id: int) -> tuple:
+    """Return (base_color, border_color) for a team's score bar."""
+    base = TEAM_COLORS.get(team_id, (120, 120, 120))
+    # Lighten the base color slightly for the border
+    border = tuple(min(255, c + 30) for c in base[:3])
+    return base, border
 
 
 def _compress_build_order(bo: list[dict]) -> list[dict]:
     """Two-level compression of a build order list.
 
-    Level 1 — same-tick, same-type entries → one entry with ``spawn_count``
+    Level 1 — same-tick, same-type entries -> one entry with ``spawn_count``
                (handles units like scouts that produce 3 per spawn cycle).
-    Level 2 — consecutive events of the same type and spawn_count → ``run_count``
+    Level 2 — consecutive events of the same type and spawn_count -> ``run_count``
                (e.g. four scout batches in a row: Scout (x3) x4).
 
     Output entries have keys: unit_type, tick, spawn_count, run_count.
@@ -160,8 +164,9 @@ class ResultsScreen(BaseScreen):
         self._team_names = team_names or {}
         self._player_names = player_names or {}
         self._player_team = player_team or {}
-        self._name1 = self._team_names.get(1, "Team 1")
-        self._name2 = self._team_names.get(2, "Team 2")
+
+        # Derive the set of team IDs from stats or player_team
+        self._team_ids: list[int] = self._derive_team_ids()
 
         # Badge row: show when 3+ players (shifts tab/graph down)
         self._show_badges = len(self._player_names) >= 3
@@ -202,9 +207,30 @@ class ResultsScreen(BaseScreen):
 
             graph_y = 125 + badge_offset
             graph_h = 340 - badge_offset
-            self._graph = LineGraph(30, graph_y, self.width - 60, graph_h,
-                                    color1=GRAPH_LINE_T1, color2=GRAPH_LINE_T2)
+            self._graph = MultiLineGraph(30, graph_y, self.width - 60, graph_h)
             self._update_graph()
+
+    def _derive_team_ids(self) -> list[int]:
+        """Build a sorted list of team IDs from stats or player_team data."""
+        ids: set[int] = set()
+        if self._stats and "teams" in self._stats:
+            for k in self._stats["teams"]:
+                try:
+                    ids.add(int(k))
+                except (ValueError, TypeError):
+                    pass
+        if self._stats and "final" in self._stats:
+            for k in self._stats["final"]:
+                try:
+                    ids.add(int(k))
+                except (ValueError, TypeError):
+                    pass
+        for t in self._player_team.values():
+            ids.add(t)
+        # Fallback if nothing found
+        if not ids:
+            ids = {1, 2}
+        return sorted(ids)
 
     def _update_graph(self):
         if not self._has_stats:
@@ -212,26 +238,39 @@ class ResultsScreen(BaseScreen):
         key = self._tabs.value
         if key == "build_order":
             return  # build order tab doesn't use graph
-        if key == "step_ms":
-            t1 = self._stats.get("step_ms", [])
-            t2 = []
-        else:
-            t1 = self._stats["teams"].get("1", {}).get(key, [])
-            t2 = self._stats["teams"].get("2", {}).get(key, [])
 
-        # Convert metal spots to build % bonus
-        if key == "metal_spots":
-            bonus_pct = METAL_EXTRACTOR_SPAWN_BONUS * 100  # 8
-            t1 = [v * bonus_pct for v in t1]
-            t2 = [v * bonus_pct for v in t2]
-
-        # Build time labels from timestamps
+        # Build series for each team
+        series: list[dict] = []
         timestamps = self._stats.get("timestamps", [])
-        x_labels = []
-        for ts in timestamps:
-            secs = ts / 60.0
-            m, s = divmod(int(secs), 60)
-            x_labels.append(f"{m}:{s:02d}")
+
+        if key == "step_ms":
+            # step_ms is global, not per-team; show as a single series
+            data = self._stats.get("step_ms", [])
+            series.append({
+                "name": "Step ms",
+                "data": data,
+                "color": GRAPH_LINE_COLORS[0],
+                "visible": True,
+            })
+        else:
+            teams_data = self._stats.get("teams", {})
+            for team_id in sorted(self._team_ids):
+                team_key = str(team_id)
+                data = teams_data.get(team_key, {}).get(key, [])
+
+                # Convert metal spots to build % bonus
+                if key == "metal_spots":
+                    bonus_pct = METAL_EXTRACTOR_SPAWN_BONUS * 100  # 8
+                    data = [v * bonus_pct for v in data]
+
+                color_idx = (team_id - 1) % len(GRAPH_LINE_COLORS)
+                team_name = self._team_names.get(team_id, f"Team {team_id}")
+                series.append({
+                    "name": team_name,
+                    "data": data,
+                    "color": GRAPH_LINE_COLORS[color_idx],
+                    "visible": True,
+                })
 
         title = dict(_TABS).get(key, key)
         self._graph.title = title
@@ -242,7 +281,7 @@ class ResultsScreen(BaseScreen):
         self._graph.y_tick_step = 8.0 if key == "metal_spots" else None
         self._graph.y_integer_ticks = key in ("army_count", "units_killed")
 
-        self._graph.set_data(t1, t2, x_labels, timestamps=timestamps)
+        self._graph.set_series(series, timestamps=timestamps)
 
     def _is_build_tab(self) -> bool:
         return self._has_stats and self._tabs.value == "build_order"
@@ -293,13 +332,13 @@ class ResultsScreen(BaseScreen):
         pygame.display.flip()
 
     def _header_text(self) -> str:
-        """Return header string: 'Draw', 'Team X Victory', or 'Defeat'."""
+        """Return header string: 'Draw', '{team_name} Victory', or 'Defeat'."""
         if self._winner == -1:
             return "Draw"
-        winner_label = f"Team {self._winner}"
+        winner_name = self._team_names.get(self._winner, f"Team {self._winner}")
         if self._human_teams and self._winner not in self._human_teams:
             return "Defeat"
-        return f"{winner_label} Victory"
+        return f"{winner_name} Victory"
 
     def _draw_simple_view(self):
         """Fallback when no stats available."""
@@ -316,7 +355,7 @@ class ResultsScreen(BaseScreen):
             winner_name = self._team_names.get(self._winner, f"Team {self._winner}")
             sub = f"{winner_name} destroyed the enemy Command Center."
         else:
-            sub = "Both Command Centers were destroyed."
+            sub = "All Command Centers were destroyed."
         sub_surf = font_sub.render(sub, True, (160, 160, 180))
         sx = self.width // 2 - sub_surf.get_width() // 2
         sy = y + surf.get_height() + 8
@@ -342,47 +381,8 @@ class ResultsScreen(BaseScreen):
         dur_surf = sub_font.render(dur_str, True, (160, 160, 180))
         self.screen.blit(dur_surf, (self.width - dur_surf.get_width() - 15, 15))
 
-        # -- Animated score bars --
-        final = self._stats.get("final", {})
-        score1 = final.get("1", {}).get("score", 0)
-        score2 = final.get("2", {}).get("score", 0)
-        total = score1 + score2
-
-        elapsed = pygame.time.get_ticks() - self._anim_start
-        progress = _ease_out_cubic(min(1.0, elapsed / _ANIM_MS))
-
-        bar_area = self.width - _BAR_PAD_X * 2 - _BAR_GAP
-        if total > 0:
-            frac1 = score1 / total
-        else:
-            frac1 = 0.5
-        w1 = int(bar_area * frac1 * progress)
-        w2 = int(bar_area * (1.0 - frac1) * progress)
-
-        # Team 1 bar — grows from left
-        r1 = pygame.Rect(_BAR_PAD_X, _BAR_Y, w1, _BAR_HEIGHT)
-        _draw_3d_bar(self.screen, r1, _BAR_T1_COLOR, _BAR_BORDER_T1)
-
-        # Team 2 bar — grows from right
-        r2_x = self.width - _BAR_PAD_X - w2
-        r2 = pygame.Rect(r2_x, _BAR_Y, w2, _BAR_HEIGHT)
-        _draw_3d_bar(self.screen, r2, _BAR_T2_COLOR, _BAR_BORDER_T2)
-
-        # Score text on bars (white)
-        score_font = _get_font(SCORE_FONT_SIZE)
-        s1_surf = score_font.render(f"{self._name1}: {score1:,}", True, (255, 255, 255))
-        s2_surf = score_font.render(f"{self._name2}: {score2:,}", True, (255, 255, 255))
-
-        # Team 1 text — always left-aligned
-        s1_y = _BAR_Y + (_BAR_HEIGHT - s1_surf.get_height()) // 2
-        if progress > 0.05:
-            self.screen.blit(s1_surf, (_BAR_PAD_X + 10, s1_y))
-
-        # Team 2 text — always right-aligned
-        s2_y = _BAR_Y + (_BAR_HEIGHT - s2_surf.get_height()) // 2
-        if progress > 0.05:
-            self.screen.blit(s2_surf,
-                             (self.width - _BAR_PAD_X - s2_surf.get_width() - 10, s2_y))
+        # -- Animated score bars (N teams, stacked vertically) --
+        self._draw_score_bars()
 
         # -- Player badges (shown when 3+ players) --
         if self._show_badges:
@@ -397,35 +397,84 @@ class ResultsScreen(BaseScreen):
         else:
             self._graph.draw(self.screen)
 
+    def _draw_score_bars(self):
+        """Draw N horizontal score bars, one per team, stacked vertically."""
+        final = self._stats.get("final", {})
+
+        # Gather scores for all teams
+        team_scores: list[tuple[int, int]] = []
+        for team_id in sorted(self._team_ids):
+            score = final.get(str(team_id), {}).get("score", 0)
+            team_scores.append((team_id, score))
+
+        max_score = max((s for _, s in team_scores), default=1)
+        if max_score <= 0:
+            max_score = 1
+
+        elapsed = pygame.time.get_ticks() - self._anim_start
+        progress = _ease_out_cubic(min(1.0, elapsed / _ANIM_MS))
+
+        bar_area = self.width - _BAR_PAD_X * 2
+        n_teams = len(team_scores)
+        score_font = _get_font(SCORE_FONT_SIZE if n_teams <= 2 else max(16, SCORE_FONT_SIZE - 4 * (n_teams - 2)))
+
+        for i, (team_id, score) in enumerate(team_scores):
+            bar_y = _BAR_Y + i * (_BAR_HEIGHT + _BAR_GAP)
+            frac = score / max_score if max_score > 0 else 0.0
+            w = int(bar_area * frac * progress)
+            w = max(w, 0)
+
+            base_color, border_color = _bar_color(team_id)
+            rect = pygame.Rect(_BAR_PAD_X, bar_y, w, _BAR_HEIGHT)
+            _draw_3d_bar(self.screen, rect, base_color, border_color)
+
+            # Score text on bar
+            team_name = self._team_names.get(team_id, f"Team {team_id}")
+            color_idx = (team_id - 1) % len(SCORE_TEAM_COLORS)
+            text_color = SCORE_TEAM_COLORS[color_idx]
+            label_surf = score_font.render(f"{team_name}: {score:,}", True, (255, 255, 255))
+
+            text_y = bar_y + (_BAR_HEIGHT - label_surf.get_height()) // 2
+            if progress > 0.05:
+                # Place text inside the bar if it fits, otherwise just after it
+                text_x = _BAR_PAD_X + 10
+                self.screen.blit(label_surf, (text_x, text_y))
+
     def _draw_player_badges(self):
         """Draw a row of colored dots + player names just below the score bars."""
-        badge_y = _BAR_Y + _BAR_HEIGHT + 4
+        n_teams = len(self._team_ids)
+        badge_y = _BAR_Y + n_teams * (_BAR_HEIGHT + _BAR_GAP) + 2
         font = _get_font(14)
-        cx = self.width // 2
 
-        # Group players by team
-        t1_pids = sorted(pid for pid, t in self._player_team.items() if t == 1)
-        t2_pids = sorted(pid for pid, t in self._player_team.items() if t == 2)
+        # Group players by team dynamically
+        team_pids: dict[int, list[int]] = {}
+        for pid, t in self._player_team.items():
+            team_pids.setdefault(t, []).append(pid)
 
-        def _draw_group(pids: list[int], start_x: int, direction: int):
-            """Draw badges starting at start_x, moving in direction (+1=right, -1=left)."""
+        # Layout: spread team groups across the width
+        sorted_teams = sorted(team_pids.keys())
+        n_groups = len(sorted_teams)
+        if n_groups == 0:
+            return
+
+        section_w = (self.width - _BAR_PAD_X * 2) // n_groups
+
+        for gi, team_id in enumerate(sorted_teams):
+            pids = sorted(team_pids[team_id])
+            start_x = _BAR_PAD_X + gi * section_w
             x = start_x
             for pid in pids:
                 name = self._player_names.get(pid, f"P{pid}")
                 color = _PLAYER_COLORS[(pid - 1) % len(_PLAYER_COLORS)]
                 dot_r = 5
-                dot_cx = x + dot_r if direction > 0 else x - dot_r
+                dot_cx = x + dot_r
                 dot_cy = badge_y + dot_r
                 pygame.draw.circle(self.screen, color, (dot_cx, dot_cy), dot_r)
                 name_surf = font.render(name, True, (180, 180, 200))
-                name_x = dot_cx + dot_r + 3 if direction > 0 else dot_cx - dot_r - 3 - name_surf.get_width()
+                name_x = dot_cx + dot_r + 3
                 self.screen.blit(name_surf, (name_x, dot_cy - name_surf.get_height() // 2))
                 item_w = dot_r * 2 + 4 + name_surf.get_width() + 10
-                x += item_w * direction
-
-        # Team 1 badges on left, team 2 on right
-        _draw_group(t1_pids, _BAR_PAD_X, 1)
-        _draw_group(list(reversed(t2_pids)), self.width - _BAR_PAD_X, -1)
+                x += item_w
 
     def _draw_build_order_tab(self):
         """Draw multi-column scrollable build order within the graph area.

--- a/systems/ai/base.py
+++ b/systems/ai/base.py
@@ -5,6 +5,7 @@ Subclass and override ``on_start`` / ``on_step`` to implement custom behavior.
 Use the built-in helper methods to query world state and issue unit commands.
 """
 from __future__ import annotations
+import math
 from abc import ABC, abstractmethod
 from entities.base import Entity
 from entities.unit import Unit
@@ -101,6 +102,36 @@ class BaseAI(ABC):
             [u for u in self._units if u.alive and u.team != self._team],
             key=lambda u: u.entity_id,
         )
+
+    def get_enemy_ccs(self) -> list[CommandCenter]:
+        """Return living command centers belonging to other teams."""
+        return [e for e in self._entities
+                if isinstance(e, CommandCenter) and e.alive and e.team != self._team]
+
+    def get_enemy_direction(self) -> tuple[float, float]:
+        """Unit vector from own CC toward average enemy CC position."""
+        cc = self.get_cc()
+        if cc is None:
+            return (1.0, 0.0)
+        enemy_ccs = self.get_enemy_ccs()
+        if not enemy_ccs:
+            return (1.0, 0.0)
+        avg_x = sum(ec.x for ec in enemy_ccs) / len(enemy_ccs)
+        avg_y = sum(ec.y for ec in enemy_ccs) / len(enemy_ccs)
+        dx, dy = avg_x - cc.x, avg_y - cc.y
+        dist = math.hypot(dx, dy) or 1.0
+        return (dx / dist, dy / dist)
+
+    def is_on_own_side(self, entity) -> bool:
+        """True if entity is closer to own CC than to any enemy CC."""
+        cc = self.get_cc()
+        if cc is None:
+            return True
+        own_dist_sq = (entity.x - cc.x) ** 2 + (entity.y - cc.y) ** 2
+        for ec in self.get_enemy_ccs():
+            if (entity.x - ec.x) ** 2 + (entity.y - ec.y) ** 2 < own_dist_sq:
+                return False
+        return True
 
     def get_mobile_units(self) -> list[Unit]:
         return sorted(

--- a/systems/arena.py
+++ b/systems/arena.py
@@ -44,9 +44,9 @@ class AIRecord:
 
 @dataclass
 class MatchResult:
-    ai1_id: str
-    ai2_id: str
-    winner: int  # 1 = ai1 won, 2 = ai2 won, -1 = draw, 0 = error
+    ai1_id: str = ""
+    ai2_id: str = ""
+    winner: int = 0  # winning team_id, -1 = draw, 0 = error
     ticks: int = 0
     avg_step_ms: float = 0.0
     replay_path: str = ""
@@ -54,6 +54,10 @@ class MatchResult:
     error_traceback: str = ""
     error_log_path: str = ""
     match_index: int = -1
+    match_format: str = "1v1"
+    # N-player fields
+    participants: list[tuple[str, int]] = field(default_factory=list)  # [(ai_id, team_id)]
+    contributions: dict[int, float] = field(default_factory=dict)  # team_id → score
 
 
 @dataclass
@@ -61,10 +65,10 @@ class TournamentProgress:
     total: int = 0
     completed: int = 0
     results: list[MatchResult] = field(default_factory=list)
-    pending_matchups: list[tuple[str, str]] = field(default_factory=list)
     done: bool = False
-    matchups: list[tuple[str, str]] = field(default_factory=list)
+    matchups: list[list[tuple[str, int]]] = field(default_factory=list)  # each: [(ai_id, team_id), ...]
     active_match_indices: list[int] = field(default_factory=list)
+    match_format: str = "1v1"
 
 
 # ---------------------------------------------------------------------------
@@ -83,17 +87,19 @@ _K = 32
 # ---------------------------------------------------------------------------
 
 def _write_error_log(
-    ai1_id: str, ai2_id: str, error_msg: str, tb: str,
+    participants: list[tuple[str, int]], error_msg: str, tb: str,
 ) -> str:
     """Write an error log for a failed match. Returns the filepath."""
     os.makedirs(_LOGS_DIR, exist_ok=True)
     ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    filename = f"error_{ai1_id}_vs_{ai2_id}_{ts}.log"
+    ids = "_vs_".join(aid for aid, _ in participants[:4])
+    filename = f"error_{ids}_{ts}.log"
     filepath = os.path.join(_LOGS_DIR, filename)
+    match_desc = " vs ".join(f"{aid}(t{tid})" for aid, tid in participants)
     lines = [
         "AIRTS Arena Match Error",
         f"Time: {datetime.now().isoformat(timespec='seconds')}",
-        f"Match: {ai1_id} vs {ai2_id}",
+        f"Match: {match_desc}",
         "=" * 60,
         error_msg.rstrip(),
         "",
@@ -149,12 +155,17 @@ def write_tournament_summary(
     lines.append("Per-Match Results")
     lines.append("=" * 60)
     for i, r in enumerate(results, 1):
-        n1 = ai_names.get(r.ai1_id, r.ai1_id)
-        n2 = ai_names.get(r.ai2_id, r.ai2_id)
-        if r.winner == 1:
-            outcome = f"{n1} wins"
-        elif r.winner == 2:
-            outcome = f"{n2} wins"
+        if r.participants:
+            match_desc = _format_match_desc(r.participants, ai_names)
+        else:
+            match_desc = f"{ai_names.get(r.ai1_id, r.ai1_id)} vs {ai_names.get(r.ai2_id, r.ai2_id)}"
+        if r.winner > 0:
+            # Find winner AI name(s)
+            winner_ids = [aid for aid, tid in r.participants if tid == r.winner] if r.participants else []
+            if winner_ids:
+                outcome = f"Team {r.winner} ({', '.join(ai_names.get(a, a) for a in winner_ids)}) wins"
+            else:
+                outcome = f"Team {r.winner} wins"
         elif r.winner == -1:
             outcome = "Draw"
         else:
@@ -162,26 +173,28 @@ def write_tournament_summary(
         secs_game = r.ticks / 60.0
         m = int(secs_game) // 60
         s = int(secs_game) % 60
-        lines.append(f"  {i:3d}. {n1} vs {n2}  ->  {outcome}  ({m}:{s:02d})")
+        lines.append(f"  {i:3d}. {match_desc}  ->  {outcome}  ({m}:{s:02d})")
 
     # Per-bot summary
     bot_stats: dict[str, dict[str, int]] = {}
     for r in results:
-        for aid in (r.ai1_id, r.ai2_id):
+        all_aids = [aid for aid, _ in r.participants] if r.participants else [r.ai1_id, r.ai2_id]
+        for aid in all_aids:
             if aid not in bot_stats:
                 bot_stats[aid] = {"wins": 0, "losses": 0, "draws": 0, "errors": 0}
         if r.winner == 0:
-            bot_stats[r.ai1_id]["errors"] += 1
-            bot_stats[r.ai2_id]["errors"] += 1
-        elif r.winner == 1:
-            bot_stats[r.ai1_id]["wins"] += 1
-            bot_stats[r.ai2_id]["losses"] += 1
-        elif r.winner == 2:
-            bot_stats[r.ai2_id]["wins"] += 1
-            bot_stats[r.ai1_id]["losses"] += 1
+            for aid in all_aids:
+                bot_stats[aid]["errors"] += 1
+        elif r.winner == -1:
+            for aid in all_aids:
+                bot_stats[aid]["draws"] += 1
         else:
-            bot_stats[r.ai1_id]["draws"] += 1
-            bot_stats[r.ai2_id]["draws"] += 1
+            winner_aids = {aid for aid, tid in r.participants if tid == r.winner} if r.participants else set()
+            for aid in all_aids:
+                if aid in winner_aids:
+                    bot_stats[aid]["wins"] += 1
+                else:
+                    bot_stats[aid]["losses"] += 1
 
     lines.append("")
     lines.append("=" * 60)
@@ -198,6 +211,22 @@ def write_tournament_summary(
     with open(filepath, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
     return filepath
+
+
+def _format_match_desc(
+    participants: list[tuple[str, int]],
+    ai_names: dict[str, str],
+) -> str:
+    """Human-readable match description from participants list."""
+    teams: dict[int, list[str]] = {}
+    for aid, tid in participants:
+        teams.setdefault(tid, []).append(ai_names.get(aid, aid))
+    sorted_teams = sorted(teams.items())
+    if len(sorted_teams) == 2 and all(len(v) == 1 for _, v in sorted_teams):
+        return f"{sorted_teams[0][1][0]} vs {sorted_teams[1][1][0]}"
+    if all(len(v) == 1 for _, v in sorted_teams):
+        return " | ".join(v[0] for _, v in sorted_teams)
+    return " vs ".join("+".join(v) for _, v in sorted_teams)
 
 
 class EloTracker:
@@ -285,6 +314,137 @@ class EloTracker:
 
         return (_K * (sa - ea), _K * (sb - eb))
 
+    def update_ffa(self, participants: list[tuple[str, int]], winner_team: int,
+                   contributions: dict[int, float] | None = None) -> None:
+        """Update ratings for a FFA match (each player = own team).
+
+        Uses pairwise Elo with K/(N-1) scaling.  Losers' penalties are
+        weighted by contribution rank: high-impact losers lose less.
+        """
+        n = len(participants)
+        if n < 2:
+            return
+        k = _K / max(n - 1, 1)
+
+        for aid, _ in participants:
+            self.ensure(aid)
+
+        if winner_team == -1:
+            # Draw — everyone gets 0.5 pairwise
+            for aid, _ in participants:
+                self.records[aid].draws += 1
+            for i, (ai, ti) in enumerate(participants):
+                for j, (aj, tj) in enumerate(participants):
+                    if j <= i:
+                        continue
+                    ra = self.records[ai].rating
+                    rb = self.records[aj].rating
+                    ea = 1.0 / (1.0 + 10.0 ** ((rb - ra) / 400.0))
+                    self.records[ai].rating += k * (0.5 - ea)
+                    self.records[aj].rating += k * (0.5 - (1.0 - ea))
+            return
+
+        winner_ids = [aid for aid, tid in participants if tid == winner_team]
+        losers = [(aid, tid) for aid, tid in participants if tid != winner_team]
+        n_losers = len(losers)
+
+        # Rank losers by contribution (descending) for penalty weighting
+        if contributions and n_losers > 1:
+            losers_sorted = sorted(losers, key=lambda x: contributions.get(x[1], 0), reverse=True)
+            loser_factors: dict[str, float] = {}
+            for rank, (aid, _) in enumerate(losers_sorted):
+                if n_losers <= 1:
+                    loser_factors[aid] = 1.0
+                else:
+                    # rank 0 = highest contrib → factor 0.5 (less loss)
+                    # rank n-1 = lowest contrib → factor 1.5 (more loss)
+                    loser_factors[aid] = 0.5 + rank * 1.0 / (n_losers - 1)
+        else:
+            loser_factors = {aid: 1.0 for aid, _ in losers}
+
+        # Pairwise: each winner vs each loser
+        for w_id in winner_ids:
+            for l_id, _ in losers:
+                ra = self.records[w_id].rating
+                rb = self.records[l_id].rating
+                ea = 1.0 / (1.0 + 10.0 ** ((rb - ra) / 400.0))
+                self.records[w_id].rating += k * (1.0 - ea)
+                self.records[l_id].rating += k * (0.0 - (1.0 - ea)) * loser_factors.get(l_id, 1.0)
+            self.records[w_id].wins += 1
+
+        for l_id, _ in losers:
+            self.records[l_id].losses += 1
+
+    def update_2v2(self, participants: list[tuple[str, int]], winner_team: int,
+                   contributions: dict[int, float] | None = None) -> None:
+        """Update ratings for a 2v2 match.
+
+        Team Elo = average of members.  Within each team, Elo change is
+        scaled by contribution: winners with high contribution gain more,
+        losers with high contribution lose less.
+        """
+        teams: dict[int, list[str]] = {}
+        for aid, tid in participants:
+            self.ensure(aid)
+            teams.setdefault(tid, []).append(aid)
+
+        team_ids = sorted(teams.keys())
+        if len(team_ids) != 2:
+            return
+
+        ta, tb = team_ids
+        avg_a = sum(self.records[a].rating for a in teams[ta]) / len(teams[ta])
+        avg_b = sum(self.records[a].rating for a in teams[tb]) / len(teams[tb])
+        ea = 1.0 / (1.0 + 10.0 ** ((avg_b - avg_a) / 400.0))
+
+        if winner_team == -1:
+            sa, sb = 0.5, 0.5
+            for aid in teams[ta] + teams[tb]:
+                self.records[aid].draws += 1
+        elif winner_team == ta:
+            sa, sb = 1.0, 0.0
+            for aid in teams[ta]:
+                self.records[aid].wins += 1
+            for aid in teams[tb]:
+                self.records[aid].losses += 1
+        elif winner_team == tb:
+            sa, sb = 0.0, 1.0
+            for aid in teams[tb]:
+                self.records[aid].wins += 1
+            for aid in teams[ta]:
+                self.records[aid].losses += 1
+        else:
+            return
+
+        base_a = _K * (sa - ea)
+        base_b = _K * (sb - (1.0 - ea))
+
+        # Distribute within teams, scaled by contribution
+        for tid, base_delta in [(ta, base_a), (tb, base_b)]:
+            members = teams[tid]
+            if len(members) == 1 or not contributions:
+                for aid in members:
+                    self.records[aid].rating += base_delta
+                continue
+            # Compute contribution shares
+            contribs = [max(contributions.get(tid, 0), 0) for _ in members]
+            # All members on same team share the same team-level contribution
+            # Use per-player contribution if available (future), else equal split
+            total_c = sum(contribs)
+            if total_c <= 0:
+                for aid in members:
+                    self.records[aid].rating += base_delta
+                continue
+            for i, aid in enumerate(members):
+                share = contribs[i] / total_c  # 0..1
+                is_winner = (base_delta > 0)
+                if is_winner:
+                    factor = 0.5 + share * len(members)  # rescaled
+                else:
+                    factor = 0.5 + (1.0 - share) * len(members)  # inverted for losers
+                # Normalize so average factor = 1.0
+                self.records[aid].rating += base_delta * factor
+
     def get_leaderboard(self) -> list[tuple[str, AIRecord]]:
         return sorted(self.records.items(), key=lambda t: t[1].rating, reverse=True)
 
@@ -294,8 +454,7 @@ class EloTracker:
 # ---------------------------------------------------------------------------
 
 def _run_arena_game(
-    ai1_id: str,
-    ai2_id: str,
+    participants: list[tuple[str, int]],
     match_index: int,
     map_width: int,
     map_height: int,
@@ -310,6 +469,20 @@ def _run_arena_game(
     _pg.init()
     _pg.display.set_mode((1, 1))
 
+    # Backward-compat: extract ai1/ai2 for legacy fields
+    ai1_id = participants[0][0] if participants else ""
+    ai2_id = participants[1][0] if len(participants) > 1 else ""
+    match_format = "1v1"
+    team_set = {tid for _, tid in participants}
+    if len(team_set) == 2:
+        team_sizes = {}
+        for _, tid in participants:
+            team_sizes[tid] = team_sizes.get(tid, 0) + 1
+        if any(v > 1 for v in team_sizes.values()):
+            match_format = "2v2"
+    elif len(team_set) > 2:
+        match_format = "ffa"
+
     try:
         from systems.ai import AIRegistry
         from systems.map_generator import DefaultMapGenerator
@@ -318,8 +491,7 @@ def _run_arena_game(
         registry = AIRegistry()
         registry.discover()
 
-        # Retry once if either bot failed to register (transient import errors)
-        needed = {ai1_id, ai2_id}
+        needed = {aid for aid, _ in participants}
         registered = {aid for aid, _ in registry.get_choices()}
         if not needed.issubset(registered):
             import time as _time
@@ -327,14 +499,23 @@ def _run_arena_game(
             registry = AIRegistry()
             registry.discover()
 
-        ai1 = registry.create(ai1_id)
-        ai2 = registry.create(ai2_id)
-        ai1_name = ai1.ai_name
-        ai2_name = ai2.ai_name
+        # Build player_ai and player_team from participants
+        player_ai = {}
+        player_team = {}
+        ai_ids_map = {}
+        ai_names_map = {}
+        for pid_idx, (aid, tid) in enumerate(participants):
+            pid = pid_idx + 1
+            ai_obj = registry.create(aid)
+            player_ai[pid] = ai_obj
+            player_team[pid] = tid
+            ai_ids_map[pid] = aid
+            ai_names_map[pid] = ai_obj.ai_name
 
         replay_config = {
-            "team_ai_ids": {1: ai1_id, 2: ai2_id},
-            "team_ai_names": {1: ai1_name, 2: ai2_name},
+            "player_ai_ids": ai_ids_map,
+            "player_ai_names": ai_names_map,
+            "player_team": player_team,
             "obstacle_count": list(obstacle_count),
             "player_name": "Arena",
         }
@@ -343,7 +524,8 @@ def _run_arena_game(
             width=map_width,
             height=map_height,
             map_generator=DefaultMapGenerator(obstacle_count=obstacle_count),
-            team_ai={1: ai1, 2: ai2},
+            player_ai=player_ai,
+            player_team=player_team,
             screen=_pg.display.get_surface(),
             clock=_pg.time.Clock(),
             replay_config=replay_config,
@@ -365,16 +547,33 @@ def _run_arena_game(
             step_ms_list = stats["step_ms"]
             avg_step_ms = sum(step_ms_list) / len(step_ms_list)
 
-        return MatchResult(ai1_id, ai2_id, winner=winner, ticks=ticks,
-                           avg_step_ms=avg_step_ms, replay_path=replay_path,
-                           match_index=match_index)
+        # Extract per-team contribution scores from stats
+        contributions: dict[int, float] = {}
+        if stats and "final" in stats:
+            for tid_str, team_final in stats["final"].items():
+                tid = int(tid_str)
+                contributions[tid] = (
+                    team_final.get("damage_dealt", 0)
+                    + team_final.get("units_killed", 0) * 50
+                    + team_final.get("metal_spots_captured", 0) * 100
+                )
+
+        return MatchResult(
+            ai1_id=ai1_id, ai2_id=ai2_id, winner=winner, ticks=ticks,
+            avg_step_ms=avg_step_ms, replay_path=replay_path,
+            match_index=match_index, match_format=match_format,
+            participants=list(participants), contributions=contributions,
+        )
 
     except Exception as exc:
         tb = traceback.format_exc()
-        error_log = _write_error_log(ai1_id, ai2_id, str(exc), tb)
-        return MatchResult(ai1_id, ai2_id, winner=0, error=str(exc),
-                           error_traceback=tb, error_log_path=error_log,
-                           match_index=match_index)
+        error_log = _write_error_log(participants, str(exc), tb)
+        return MatchResult(
+            ai1_id=ai1_id, ai2_id=ai2_id, winner=0, error=str(exc),
+            error_traceback=tb, error_log_path=error_log,
+            match_index=match_index, match_format=match_format,
+            participants=list(participants),
+        )
 
     finally:
         _pg.quit()
@@ -385,30 +584,30 @@ def _run_arena_game(
 # ---------------------------------------------------------------------------
 
 def _distribute_matchups(
-    matchups: list[tuple[str, str, int]], n_workers: int,
-) -> list[list[tuple[str, str, int]]]:
+    matchups: list[tuple[list[tuple[str, int]], int]], n_workers: int,
+) -> list[list[tuple[list[tuple[str, int]], int]]]:
     """Greedy bot-aware assignment of matchups to worker queues.
 
-    Each entry is (ai1_id, ai2_id, match_index).  Assigns each matchup to
-    the worker whose queue has the fewest matches involving either bot,
+    Each entry is (participants, match_index).  Assigns each matchup to
+    the worker whose queue has the fewest matches involving any participating bot,
     tiebreak by shortest queue.
     """
-    queues: list[list[tuple[str, str, int]]] = [[] for _ in range(n_workers)]
-    # Per-worker bot counts for fast lookup
+    queues: list[list[tuple[list[tuple[str, int]], int]]] = [[] for _ in range(n_workers)]
     bot_counts: list[dict[str, int]] = [{} for _ in range(n_workers)]
 
-    for ai1, ai2, idx in matchups:
+    for parts, idx in matchups:
+        aids = [aid for aid, _ in parts]
         best_w = 0
         best_score = (float("inf"), float("inf"))
         for w in range(n_workers):
-            overlap = bot_counts[w].get(ai1, 0) + bot_counts[w].get(ai2, 0)
+            overlap = sum(bot_counts[w].get(a, 0) for a in aids)
             score = (overlap, len(queues[w]))
             if score < best_score:
                 best_score = score
                 best_w = w
-        queues[best_w].append((ai1, ai2, idx))
-        bot_counts[best_w][ai1] = bot_counts[best_w].get(ai1, 0) + 1
-        bot_counts[best_w][ai2] = bot_counts[best_w].get(ai2, 0) + 1
+        queues[best_w].append((parts, idx))
+        for a in aids:
+            bot_counts[best_w][a] = bot_counts[best_w].get(a, 0) + 1
 
     return queues
 
@@ -422,10 +621,11 @@ class ArenaRunner:
         self._results: list[MatchResult] = []
         self._total: int = 0
         self._running: bool = False
-        self._matchups: list[tuple[str, str]] = []
+        self._matchups: list[list[tuple[str, int]]] = []  # each: [(ai_id, team_id), ...]
+        self._match_format: str = "1v1"
 
         # Slot-based state
-        self._worker_queues: list[list[tuple[str, str, int]]] = []
+        self._worker_queues: list[list[tuple[list[tuple[str, int]], int]]] = []
         self._active_futures: dict[int, tuple[Future, int]] = {}  # slot -> (future, match_index)
         self._n_workers: int = 0
 
@@ -448,24 +648,51 @@ class ArenaRunner:
         map_height: int = 600,
         obstacle_count: tuple[int, int] = (4, 8),
         max_ticks: int = 54000,
+        match_format: str = "1v1",
     ) -> None:
-        """Generate round-robin matchups, distribute to worker queues, start."""
+        """Generate matchups based on format, distribute to worker queues, start."""
         if self._running:
             return
 
-        # Build matchup list: each pair plays both sides × rounds
-        matchups: list[tuple[str, str]] = []
-        for i, a in enumerate(ai_ids):
-            for b in ai_ids[i + 1:]:
-                for _ in range(rounds):
-                    matchups.append((a, b))
-                    matchups.append((b, a))
+        self._match_format = match_format
+
+        # Build matchup list based on format
+        matchups: list[list[tuple[str, int]]] = []
+
+        if match_format == "ffa":
+            # All AIs in one match, each on their own team
+            base = [(aid, i + 1) for i, aid in enumerate(ai_ids)]
+            for _ in range(rounds):
+                matchups.append(list(base))
+
+        elif match_format == "2v2":
+            from itertools import combinations
+            # Generate all valid 2v2 team pairings
+            team_combos = list(combinations(range(len(ai_ids)), 2))
+            for i, combo_a in enumerate(team_combos):
+                for combo_b in team_combos[i + 1:]:
+                    if set(combo_a) & set(combo_b):
+                        continue  # skip if same AI on both teams
+                    parts = [
+                        (ai_ids[combo_a[0]], 1), (ai_ids[combo_a[1]], 1),
+                        (ai_ids[combo_b[0]], 2), (ai_ids[combo_b[1]], 2),
+                    ]
+                    for _ in range(rounds):
+                        matchups.append(parts)
+
+        else:
+            # 1v1 round-robin: each pair plays both sides × rounds
+            for i, a in enumerate(ai_ids):
+                for b in ai_ids[i + 1:]:
+                    for _ in range(rounds):
+                        matchups.append([(a, 1), (b, 2)])
+                        matchups.append([(b, 1), (a, 2)])
 
         self._matchups = matchups
         self._total = len(matchups)
         self._results = []
         self._running = True
-        self._n_workers = min(workers, self._total)
+        self._n_workers = min(workers, max(self._total, 1))
 
         # Store game params
         self._map_width = map_width
@@ -474,7 +701,7 @@ class ArenaRunner:
         self._max_ticks = max_ticks
 
         # Distribute into per-worker queues
-        indexed = [(a, b, idx) for idx, (a, b) in enumerate(matchups)]
+        indexed = [(parts, idx) for idx, parts in enumerate(matchups)]
         self._worker_queues = _distribute_matchups(indexed, self._n_workers)
         self._active_futures = {}
 
@@ -486,9 +713,9 @@ class ArenaRunner:
         """Pop next matchup from this worker's queue and submit it."""
         if not self._worker_queues[slot]:
             return
-        ai1, ai2, match_index = self._worker_queues[slot].pop(0)
+        participants, match_index = self._worker_queues[slot].pop(0)
         fut = self._executor.submit(
-            _run_arena_game, ai1, ai2, match_index,
+            _run_arena_game, participants, match_index,
             self._map_width, self._map_height,
             self._obstacle_count, self._max_ticks,
         )
@@ -500,7 +727,7 @@ class ArenaRunner:
             return TournamentProgress(
                 done=True, results=self._results,
                 total=self._total, completed=len(self._results),
-                matchups=self._matchups,
+                matchups=self._matchups, match_format=self._match_format,
             )
 
         # Check active futures for completion
@@ -510,9 +737,11 @@ class ArenaRunner:
                 try:
                     result = fut.result()
                 except Exception as exc:
-                    ai1, ai2 = self._matchups[match_index]
-                    result = MatchResult(ai1, ai2, winner=0, error=str(exc),
-                                         match_index=match_index)
+                    parts = self._matchups[match_index]
+                    result = MatchResult(
+                        winner=0, error=str(exc), match_index=match_index,
+                        participants=list(parts), match_format=self._match_format,
+                    )
                 self._results.append(result)
                 completed_slots.append(slot)
 
@@ -539,6 +768,7 @@ class ArenaRunner:
             done=done,
             matchups=self._matchups,
             active_match_indices=active_indices,
+            match_format=self._match_format,
         )
 
     def cancel(self) -> None:

--- a/systems/capturing.py
+++ b/systems/capturing.py
@@ -30,13 +30,7 @@ def capture_step(entities: list[Entity], command_centers: list[CommandCenter], u
             weight = 0.3 if unit.unit_type == "scout" else 1.0
             team_counts[unit.team] += weight
 
-        # unit_difference: positive = all_teams[0] leads, negative = all_teams[1] leads
-        if len(all_teams) >= 2:
-            unit_difference = team_counts[all_teams[0]] - team_counts[all_teams[1]]
-        else:
-            unit_difference = team_counts[all_teams[0]] if all_teams else 0.0
-
-        metal_spot.update_progress(unit_difference, dt)
+        metal_spot.update_progress(team_counts, dt)
 
         def _claim_for(claiming_team: int):
             metal_spot.claim(claiming_team)
@@ -50,7 +44,8 @@ def capture_step(entities: list[Entity], command_centers: list[CommandCenter], u
             if stats is not None:
                 stats.record_capture(claiming_team)
 
-        if metal_spot.capture_progress >= 1.0:
-            _claim_for(all_teams[0])
-        elif metal_spot.capture_progress <= -1.0 and len(all_teams) >= 2:
-            _claim_for(all_teams[1])
+        # Check if any team has completed capture
+        for tid, prog in list(metal_spot.capture_progress.items()):
+            if prog >= 1.0:
+                _claim_for(tid)
+                break

--- a/systems/map_generator.py
+++ b/systems/map_generator.py
@@ -22,7 +22,7 @@ class BaseMapGenerator:
 
 
 class DefaultMapGenerator(BaseMapGenerator):
-    """Random obstacles in the center band, one command center per side."""
+    """Random obstacles, command centers placed by team layout."""
 
     def __init__(self, obstacle_count: tuple[int, int] = (4, 8),
                  metal_spots_per_side: int = 0):
@@ -31,8 +31,10 @@ class DefaultMapGenerator(BaseMapGenerator):
 
     def generate(self, width: int, height: int, player_team: dict | None = None) -> list[Entity]:
         entities: list[Entity] = []
-        self._place_command_centers(entities, width, height, player_team or {1: 1, 2: 2})
-        self._place_metal_spots(entities, width, height)
+        pt = player_team or {1: 1, 2: 2}
+        self._place_command_centers(entities, width, height, pt)
+        n_teams = len({t for t in pt.values()})
+        self._place_metal_spots(entities, width, height, n_teams)
         self._place_obstacles(entities, width, height)
         return entities
 
@@ -98,36 +100,105 @@ class DefaultMapGenerator(BaseMapGenerator):
             tid = player_team[pid]
             team_players.setdefault(tid, []).append(pid)
 
-        # Assign each team to a horizontal side
         sorted_teams = sorted(team_players)
-        n_teams = max(len(sorted_teams), 2)
-        # x positions: divide width into n_teams strips, inset 80px from each edge
-        inset = 80
-        if n_teams == 2:
-            side_xs = {sorted_teams[0]: inset, sorted_teams[1]: width - inset}
+        n_teams = len(sorted_teams)
+
+        if n_teams <= 2:
+            # Classic left/right placement
+            inset = 80
+            n_slots = max(n_teams, 2)
+            if n_slots == 2 and n_teams == 2:
+                side_xs = {sorted_teams[0]: inset, sorted_teams[1]: width - inset}
+            elif n_teams == 1:
+                side_xs = {sorted_teams[0]: inset}
+            else:
+                side_xs = {sorted_teams[0]: inset, sorted_teams[1]: width - inset}
+
+            for tid, pids in team_players.items():
+                sx = side_xs[tid]
+                m = len(pids)
+                for j, pid in enumerate(pids):
+                    sy = height * (j + 1) / (m + 1)
+                    cc = CommandCenter(sx, sy, team=tid, player_id=pid)
+                    cc._bounds = (width, height)
+                    cc._spawn_timer = CC_SPAWN_INTERVAL
+                    entities.append(cc)
         else:
-            side_xs = {
-                tid: inset + i * (width - 2 * inset) / (n_teams - 1)
-                for i, tid in enumerate(sorted_teams)
-            }
+            # Radial placement for 3+ teams
+            cx, cy = width / 2, height / 2
+            radius = min(width, height) * 0.35
+            for i, tid in enumerate(sorted_teams):
+                angle = 2 * math.pi * i / n_teams - math.pi / 2  # start at top
+                sx = cx + radius * math.cos(angle)
+                sy = cy + radius * math.sin(angle)
+                pids = team_players[tid]
+                m = len(pids)
+                for j, pid in enumerate(pids):
+                    # Offset multiple players on same team perpendicular to radial
+                    if m > 1:
+                        perp_angle = angle + math.pi / 2
+                        offset = (j - (m - 1) / 2) * 40
+                        px = sx + offset * math.cos(perp_angle)
+                        py = sy + offset * math.sin(perp_angle)
+                    else:
+                        px, py = sx, sy
+                    cc = CommandCenter(px, py, team=tid, player_id=pid)
+                    cc._bounds = (width, height)
+                    cc._spawn_timer = CC_SPAWN_INTERVAL
+                    entities.append(cc)
 
-        for tid, pids in team_players.items():
-            sx = side_xs[tid]
-            m = len(pids)
-            for j, pid in enumerate(pids):
-                # Distribute vertically: 1 player → center, N players → evenly spaced
-                sy = height * (j + 1) / (m + 1)
-                cc = CommandCenter(sx, sy, team=tid, player_id=pid)
-                cc._bounds = (width, height)
-                cc._spawn_timer = CC_SPAWN_INTERVAL
-                entities.append(cc)
-
-    def _place_metal_spots(self, entities: list[Entity], width: int, height: int):
+    def _place_metal_spots(self, entities: list[Entity], width: int, height: int,
+                           n_teams: int = 2):
         count = self._metal_spots_per_side if self._metal_spots_per_side > 0 else random.randint(2, 4)
-        for _ in range(count):
-            x = random.uniform(200 + METAL_SPOT_RADIUS, width // 2 - METAL_SPOT_RADIUS)
-            y = random.uniform(60 + METAL_SPOT_RADIUS, height // 2 - METAL_SPOT_RADIUS)
-            metal_spot = MetalSpot(x, y)
-            metal_spot_2 = MetalSpot(width - x, height - y)
-            entities.append(metal_spot)
-            entities.append(metal_spot_2)
+
+        if n_teams <= 2:
+            # Classic mirror: left half → right half
+            for _ in range(count):
+                x = random.uniform(200 + METAL_SPOT_RADIUS, width // 2 - METAL_SPOT_RADIUS)
+                y = random.uniform(60 + METAL_SPOT_RADIUS, height // 2 - METAL_SPOT_RADIUS)
+                metal_spot = MetalSpot(x, y)
+                metal_spot_2 = MetalSpot(width - x, height - y)
+                entities.append(metal_spot)
+                entities.append(metal_spot_2)
+        else:
+            # N-fold rotational symmetry around map center
+            cx, cy = width / 2, height / 2
+            min_dist = 60.0
+            max_dist = min(width, height) * 0.35 - 20
+            sector_angle = 2 * math.pi / n_teams
+            ccs = [e for e in entities if isinstance(e, CommandCenter)]
+
+            for _ in range(count):
+                # Pick random point in one sector (the first sector)
+                for _attempt in range(50):
+                    angle = random.uniform(0.1, sector_angle - 0.1)
+                    dist = random.uniform(min_dist, max_dist)
+                    valid = True
+                    # Check all N rotated copies are within bounds and away from CCs
+                    spots_to_add = []
+                    for k in range(n_teams):
+                        rot = sector_angle * k
+                        mx = cx + dist * math.cos(angle + rot)
+                        my = cy + dist * math.sin(angle + rot)
+                        # Bounds check with margin
+                        if mx < METAL_SPOT_RADIUS + 10 or mx > width - METAL_SPOT_RADIUS - 10:
+                            valid = False
+                            break
+                        if my < METAL_SPOT_RADIUS + 10 or my > height - METAL_SPOT_RADIUS - 10:
+                            valid = False
+                            break
+                        # CC exclusion
+                        if any(math.hypot(mx - cc.x, my - cc.y) < CC_OBSTACLE_EXCLUSION
+                               for cc in ccs):
+                            valid = False
+                            break
+                        # Overlap with existing metal spots
+                        if any(math.hypot(mx - e.x, my - e.y) < METAL_SPOT_RADIUS * 3
+                               for e in entities if isinstance(e, MetalSpot)):
+                            valid = False
+                            break
+                        spots_to_add.append(MetalSpot(mx, my))
+                    if valid and len(spots_to_add) == n_teams:
+                        for ms in spots_to_add:
+                            entities.append(ms)
+                        break

--- a/systems/replay.py
+++ b/systems/replay.py
@@ -23,6 +23,18 @@ RECORD_INTERVAL = 6
 # How many *recorded frames* between full keyframes
 KEYFRAME_INTERVAL = 60
 
+def normalize_cp(raw) -> dict[int, float]:
+    """Normalize capture_progress from either legacy float or new dict format."""
+    if isinstance(raw, dict):
+        return {int(k): float(v) for k, v in raw.items()}
+    if isinstance(raw, (int, float)):
+        if raw > 0.001:
+            return {1: float(raw)}
+        elif raw < -0.001:
+            return {2: abs(float(raw))}
+    return {}
+
+
 # Short type codes
 _TYPE_CODE = {
     "Unit": "U",
@@ -146,7 +158,7 @@ def _entity_visual(e: Entity) -> dict | None:
             "y": _q1(e.y),
             "r": e.radius,
             "ow": e.owner,
-            "cp": _q2(e.capture_progress),
+            "cp": {str(tid): _q2(val) for tid, val in e.capture_progress.items()} if e.capture_progress else {},
         }
     # Obstacles and other shapes are stored in map.obstacles, not frames
     return None
@@ -330,7 +342,7 @@ class ReplayRecorder:
         duration_seconds = round(duration_ticks / 60.0, 2)
 
         data = {
-            "version": 1,
+            "version": 2,
             "timestamp": datetime.now().isoformat(timespec="seconds"),
             "duration_ticks": duration_ticks,
             "duration_seconds": duration_seconds,

--- a/test/test_results_labels.py
+++ b/test/test_results_labels.py
@@ -16,19 +16,18 @@ def _make_results(**kwargs):
 class TestCombinedTeamNames:
     def test_1v1_name_passthrough(self):
         r = _make_results(team_names={1: "EasyAI", 2: "WanderAI"})
-        assert r._name1 == "EasyAI"
-        assert r._name2 == "WanderAI"
+        assert r._team_names[1] == "EasyAI"
+        assert r._team_names[2] == "WanderAI"
 
     def test_default_team_names(self):
         r = _make_results()
-        assert r._name1 == "Team 1"
-        assert r._name2 == "Team 2"
+        assert r._team_names == {}
 
     def test_2v2_joined_names(self):
         """game.py produces joined names; ResultsScreen just stores them."""
         r = _make_results(team_names={1: "EasyAI & Wander", 2: "HardAI & Peri AI"})
-        assert r._name1 == "EasyAI & Wander"
-        assert r._name2 == "HardAI & Peri AI"
+        assert r._team_names[1] == "EasyAI & Wander"
+        assert r._team_names[2] == "HardAI & Peri AI"
 
 
 class TestGameTeamNamesJoining:

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -92,15 +92,46 @@ BG_DOT_COUNT = 30
 GRAPH_BG = (20, 20, 32)
 GRAPH_GRID = (40, 40, 55)
 GRAPH_AXIS_TEXT = (140, 140, 160)
-GRAPH_LINE_T1 = (80, 160, 255)
-GRAPH_LINE_T2 = (255, 90, 90)
-GRAPH_FILL_T1 = (80, 160, 255, 30)
-GRAPH_FILL_T2 = (255, 90, 90, 30)
+GRAPH_LINE_COLORS = [
+    (80,  160, 255),  # T1 blue
+    (255,  90,  90),  # T2 red
+    (80,  220, 160),  # T3 teal
+    (255, 165,  60),  # T4 orange
+    (180, 100, 255),  # T5 purple
+    (80,  220, 220),  # T6 cyan
+    (220, 220,  80),  # T7 yellow
+    (220,  80, 160),  # T8 pink
+]
+GRAPH_FILL_COLORS = [
+    (80,  160, 255, 30),
+    (255,  90,  90, 30),
+    (80,  220, 160, 30),
+    (255, 165,  60, 30),
+    (180, 100, 255, 30),
+    (80,  220, 220, 30),
+    (220, 220,  80, 30),
+    (220,  80, 160, 30),
+]
+SCORE_TEAM_COLORS = [
+    (100, 180, 255),  # T1
+    (255, 120, 120),  # T2
+    (100, 230, 170),  # T3
+    (255, 180,  80),  # T4
+    (190, 130, 255),  # T5
+    (100, 230, 230),  # T6
+    (230, 230, 100),  # T7
+    (230, 100, 170),  # T8
+]
+# Backward-compat aliases
+GRAPH_LINE_T1 = GRAPH_LINE_COLORS[0]
+GRAPH_LINE_T2 = GRAPH_LINE_COLORS[1]
+GRAPH_FILL_T1 = GRAPH_FILL_COLORS[0]
+GRAPH_FILL_T2 = GRAPH_FILL_COLORS[1]
+SCORE_T1_COLOR = SCORE_TEAM_COLORS[0]
+SCORE_T2_COLOR = SCORE_TEAM_COLORS[1]
 GRAPH_TITLE_COLOR = (200, 200, 220)
 GRAPH_FONT_SIZE = 14
 SCORE_FONT_SIZE = 28
-SCORE_T1_COLOR = (100, 180, 255)
-SCORE_T2_COLOR = (255, 120, 120)
 STATS_HEADER_FONT_SIZE = 40
 
 # -- debug performance graph ------------------------------------------------

--- a/ui/widgets.py
+++ b/ui/widgets.py
@@ -538,7 +538,7 @@ class Checkbox:
 # ---------------------------------------------------------------------------
 
 class LineGraph:
-    """Draws a line graph with two data series (team 1 and team 2)."""
+    """Draws a line graph with N data series."""
 
     def __init__(
         self,
@@ -553,6 +553,8 @@ class LineGraph:
         self.color2 = color2
         self.data1: list[float] = []
         self.data2: list[float] = []
+        # N-series support: list of (data, color, label)
+        self._series: list[tuple[list[float], tuple, str]] = []
         self.x_labels: list[str] | None = None  # optional time labels
         self.timestamps: list[int] | None = None  # raw tick values for x-axis
         self.y_suffix: str = ""  # appended to y-axis labels (e.g. "%")
@@ -562,11 +564,24 @@ class LineGraph:
         self._hover_index: int | None = None
         self._hover_mouse_y: int = 0
 
-    def set_data(self, data1: list[float], data2: list[float],
+    def set_data(self, data1: list[float], data2: list[float] | None = None,
                  x_labels: list[str] | None = None,
                  timestamps: list[int] | None = None):
+        """Backward-compat: set 1 or 2 series."""
         self.data1 = data1
-        self.data2 = data2
+        self.data2 = data2 if data2 is not None else []
+        self._series = []  # clear N-series when using legacy API
+        self.x_labels = x_labels
+        self.timestamps = timestamps
+
+    def set_series(self, series: list[tuple[list[float], tuple, str]],
+                   x_labels: list[str] | None = None,
+                   timestamps: list[int] | None = None):
+        """Set N data series. Each entry is (data, color, label)."""
+        self._series = series
+        # Also populate data1/data2 for backward compat in hover/draw logic
+        self.data1 = series[0][0] if len(series) > 0 else []
+        self.data2 = series[1][0] if len(series) > 1 else []
         self.x_labels = x_labels
         self.timestamps = timestamps
 
@@ -585,7 +600,7 @@ class LineGraph:
             gw = self.rect.w - margin_l - margin_r
             gh = self.rect.h - margin_t - margin_b
 
-            n = max(len(self.data1), len(self.data2))
+            n = max((len(s[0]) for s in self._series), default=0) if self._series else max(len(self.data1), len(self.data2))
             if gw > 0 and gh > 0 and n >= 2 and gx <= mx <= gx + gw and gy <= my <= gy + gh:
                 frac = (mx - gx) / gw
                 idx = round(frac * (n - 1))
@@ -702,9 +717,20 @@ class LineGraph:
         if gw <= 0 or gh <= 0:
             return
 
-        n1 = len(self.data1)
-        n2 = len(self.data2)
-        n = max(n1, n2)
+        # Resolve series list
+        if self._series:
+            series = self._series
+        else:
+            series = []
+            if self.data1:
+                series.append((self.data1, self.color1, "T1"))
+            if self.data2:
+                series.append((self.data2, self.color2, "T2"))
+
+        n = max((len(s[0]) for s in series), default=0) if series else 0
+        # Backward-compat accessors for hover code
+        n1 = len(series[0][0]) if len(series) > 0 else 0
+        n2 = len(series[1][0]) if len(series) > 1 else 0
         if n < 2:
             no_data = font.render("No data", True, GRAPH_AXIS_TEXT)
             surface.blit(no_data, (gx + gw // 2 - no_data.get_width() // 2,
@@ -712,7 +738,9 @@ class LineGraph:
             return
 
         # Compute Y range
-        all_vals = self.data1 + self.data2
+        all_vals = []
+        for s_data, _, _ in series:
+            all_vals.extend(s_data)
         y_min = 0.0
         data_max = max(all_vals) if all_vals else 1.0
         if data_max <= y_min:
@@ -761,13 +789,11 @@ class LineGraph:
                 pts.append((px, py))
             return pts
 
-        # Draw lines
-        if n1 >= 2:
-            pts1 = _data_to_points(self.data1)
-            pygame.draw.lines(surface, self.color1, False, pts1, 2)
-        if n2 >= 2:
-            pts2 = _data_to_points(self.data2)
-            pygame.draw.lines(surface, self.color2, False, pts2, 2)
+        # Draw lines for all series
+        for s_data, s_color, _ in series:
+            if len(s_data) >= 2:
+                pts = _data_to_points(s_data)
+                pygame.draw.lines(surface, s_color, False, pts, 2)
 
         # Hover tooltip
         if self._hover_index is not None and n >= 2:
@@ -784,12 +810,12 @@ class LineGraph:
                 frac = (val - y_min) / (y_max - y_min) if y_max > y_min else 0
                 return gy + gh - int(frac * gh)
 
-            v1 = self.data1[hi] if hi < n1 else None
-            v2 = self.data2[hi] if hi < n2 else None
-            if v1 is not None:
-                pygame.draw.circle(surface, self.color1, (hx_pos, _val_y(v1)), 4)
-            if v2 is not None:
-                pygame.draw.circle(surface, self.color2, (hx_pos, _val_y(v2)), 4)
+            hover_vals = []
+            for s_data, s_color, s_label in series:
+                v = s_data[hi] if hi < len(s_data) else None
+                hover_vals.append((v, s_color, s_label))
+                if v is not None:
+                    pygame.draw.circle(surface, s_color, (hx_pos, _val_y(v)), 4)
 
             # Tooltip box
             tip_font = _get_font(GRAPH_FONT_SIZE)
@@ -802,15 +828,16 @@ class LineGraph:
                     return self.value_format.format(v) + self.y_suffix
                 return f"{int(v)}{self.y_suffix}"
 
-            t1_str = f"T1: {_fmt_val(v1)}"
-            t2_str = f"T2: {_fmt_val(v2)}"
-
             time_s = tip_font.render(time_str, True, (220, 220, 240))
-            t1_s = tip_font.render(t1_str, True, self.color1)
-            t2_s = tip_font.render(t2_str, True, self.color2)
-
-            tip_w = max(time_s.get_width(), t1_s.get_width(), t2_s.get_width()) + 12
-            tip_h = time_s.get_height() + t1_s.get_height() + t2_s.get_height() + 12
+            tip_rendered = [time_s]
+            tip_w = time_s.get_width()
+            for v, s_color, s_label in hover_vals:
+                txt = f"{s_label}: {_fmt_val(v)}"
+                rendered = tip_font.render(txt, True, s_color)
+                tip_rendered.append(rendered)
+                tip_w = max(tip_w, rendered.get_width())
+            tip_w += 12
+            tip_h = sum(s.get_height() for s in tip_rendered) + 4 + 2 * len(tip_rendered)
 
             # Position tooltip to stay inside graph bounds
             tip_x = hx_pos + 10
@@ -824,11 +851,9 @@ class LineGraph:
             pygame.draw.rect(surface, (80, 80, 110), tip_rect, 1, border_radius=3)
 
             cy_tip = tip_y + 4
-            surface.blit(time_s, (tip_x + 6, cy_tip))
-            cy_tip += time_s.get_height() + 2
-            surface.blit(t1_s, (tip_x + 6, cy_tip))
-            cy_tip += t1_s.get_height() + 2
-            surface.blit(t2_s, (tip_x + 6, cy_tip))
+            for rendered in tip_rendered:
+                surface.blit(rendered, (tip_x + 6, cy_tip))
+                cy_tip += rendered.get_height() + 2
 
 
 # ---------------------------------------------------------------------------
@@ -847,6 +872,11 @@ class MultiLineGraph:
         self._hover_index: int | None = None
         self._hover_mouse_y: int = 0
         self._legend_rects: list[pygame.Rect] = []  # hit areas per series
+        # Formatting options (mirrored from LineGraph for compatibility)
+        self.y_suffix: str = ""  # appended to y-axis labels (e.g. "%")
+        self.y_tick_step: float | None = None  # explicit y-axis step
+        self.y_integer_ticks: bool = False  # snap y ticks to nice whole numbers
+        self.value_format: str | None = None  # tooltip format (e.g. "{:.2f}")
 
     def set_series(self, series_list: list[dict],
                    timestamps: list[int] | None = None):
@@ -915,6 +945,31 @@ class MultiLineGraph:
     # -- y/x tick computation (reused from LineGraph logic) -------------------
 
     def _compute_y_ticks(self, data_max: float) -> list[float]:
+        if self.y_tick_step is not None:
+            step = self.y_tick_step
+            ticks: list[float] = []
+            v = 0.0
+            top = data_max + step
+            while v <= top:
+                ticks.append(v)
+                v += step
+            return ticks
+
+        if self.y_integer_ticks:
+            nice_int = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000]
+            step_i = nice_int[-1]
+            for s in nice_int:
+                if data_max / s <= 6:
+                    step_i = s
+                    break
+            ticks = []
+            v_i = 0
+            top_i = data_max + step_i
+            while v_i <= top_i:
+                ticks.append(float(v_i))
+                v_i += step_i
+            return ticks
+
         nice_steps = [0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500]
         step = nice_steps[-1]
         for s in nice_steps:
@@ -1013,6 +1068,7 @@ class MultiLineGraph:
                 lbl = f"{val:.0f}"
             else:
                 lbl = f"{val:.1f}"
+            lbl += self.y_suffix
             ls = font.render(lbl, True, GRAPH_AXIS_TEXT)
             surface.blit(ls, (gx - ls.get_width() - 4, ly - ls.get_height() // 2))
 
@@ -1088,7 +1144,11 @@ class MultiLineGraph:
             for s in self._series:
                 if s["visible"] and hi < len(s["data"]):
                     val = s["data"][hi]
-                    lines_text.append(f"{s['name']}: {val:.2f}")
+                    if self.value_format:
+                        val_str = self.value_format.format(val) + self.y_suffix
+                    else:
+                        val_str = f"{int(val)}{self.y_suffix}"
+                    lines_text.append(f"{s['name']}: {val_str}")
                     lines_colors.append(s["color"])
 
             rendered = [tip_font.render(t, True, c)


### PR DESCRIPTION
Replaced hardcoded 2-team logic throughout the codebase with dynamic
   N-team support. Key changes:

   - Per-team capture progress (dict) replacing binary float on metal spots
   - Radial CC placement and N-fold symmetric metal spots for 3+ teams
   - FFA and 2v2 arena formats with contribution-weighted pairwise Elo
   - N-team UI across results, replay playback, lobby, and client screens
   - LineGraph widget supports N series instead of fixed 2
   - CC-relative AI helpers replacing map-midpoint logic in all bot files
   - Replay v2 format with backward-compatible capture progress loading
   - Win condition: game continues until <= 1 team has living CCs
   - PLAYER_COLORS modulo-wrapped to prevent IndexError with >8 players
   - Multiplayer lobby host team dropdown and dynamic team construction
   - CLI --teams and --player args for flexible FFA/team setups