### PR TITLE
Add selection hotkeys, rectangle/circle drag-select mode, and double-click select-all-of-type

### DIFF
--- a/config/display.py
+++ b/config/display.py
@@ -7,17 +7,25 @@ import pygame
 _SETTINGS_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "display_settings.json")
 
 display_mode: str = "windowed_fullscreen"
+color_mode: str = "player"          # "player" or "team"
+selection_mode: str = "rectangle"   # "rectangle" or "circle"
 
 
 def load_settings() -> None:
     """Load display settings from disk."""
-    global display_mode
+    global display_mode, color_mode, selection_mode
     try:
         with open(_SETTINGS_PATH, "r") as f:
             data = json.load(f)
         mode = data.get("display_mode", "windowed_fullscreen")
         if mode in ("windowed_fullscreen", "windowed"):
             display_mode = mode
+        cm = data.get("color_mode", "player")
+        if cm in ("player", "team"):
+            color_mode = cm
+        sm = data.get("selection_mode", "rectangle")
+        if sm in ("rectangle", "circle"):
+            selection_mode = sm
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         pass
 
@@ -26,7 +34,11 @@ def save_settings() -> None:
     """Persist display settings to disk."""
     try:
         with open(_SETTINGS_PATH, "w") as f:
-            json.dump({"display_mode": display_mode}, f, indent=2)
+            json.dump({
+                "display_mode": display_mode,
+                "color_mode": color_mode,
+                "selection_mode": selection_mode,
+            }, f, indent=2)
     except OSError:
         pass
 
@@ -36,6 +48,22 @@ def set_mode(mode: str) -> None:
     global display_mode
     if mode in ("windowed_fullscreen", "windowed"):
         display_mode = mode
+        save_settings()
+
+
+def set_color_mode(mode: str) -> None:
+    """Update color mode and save."""
+    global color_mode
+    if mode in ("player", "team"):
+        color_mode = mode
+        save_settings()
+
+
+def set_selection_mode(mode: str) -> None:
+    """Update selection mode and save."""
+    global selection_mode
+    if mode in ("rectangle", "circle"):
+        selection_mode = mode
         save_settings()
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -23,16 +23,16 @@ PLAYER_COLORS = [
     (220,  80, 160),  # P8 pink
 ]
 
-# Per-team colours used for team-scoped visuals (capture arcs, minimap borders)
+# Per-team colours — matches PLAYER_COLORS order so FFA (player==team) is consistent
 TEAM_COLORS = {
-    1: (80,  140, 255),  # T1 blue
-    2: (255,  80,  80),  # T2 red
-    3: (80,  220, 160),  # T3 teal
-    4: (255, 160,  60),  # T4 orange
-    5: (180,  80, 220),  # T5 purple
-    6: (80,  220, 220),  # T6 cyan
-    7: (220, 220,  80),  # T7 yellow
-    8: (220,  80, 160),  # T8 pink
+    1: (80,  140, 255),  # T1 blue     (= P1)
+    2: (80,  220, 160),  # T2 teal     (= P2)
+    3: (255,  80,  80),  # T3 red      (= P3)
+    4: (255, 160,  60),  # T4 orange   (= P4)
+    5: (180,  80, 220),  # T5 purple   (= P5)
+    6: (80,  220, 220),  # T6 cyan     (= P6)
+    7: (220, 220,  80),  # T7 yellow   (= P7)
+    8: (220,  80, 160),  # T8 pink     (= P8)
 }
 
 # Backward-compat aliases (metal_spot.py / metal_extractor.py still reference these)

--- a/entities/metal_extractor.py
+++ b/entities/metal_extractor.py
@@ -143,6 +143,8 @@ class MetalExtractor(Unit):
         ]
         rotated_points = [p * complex(math.cos(self.rotation), math.sin(self.rotation)) for p in static_points]
         points = [(p.real + self.x, p.imag + self.y) for p in rotated_points]
+        color = PLAYER_COLORS[(self.team - 1) % len(PLAYER_COLORS)]
+        pygame.draw.polygon(surface, color, points)
         pygame.draw.polygon(surface, (0, 0, 0), points, 1)
 
     def _draw_watch_tower(self, surface: pygame.Surface):

--- a/game.py
+++ b/game.py
@@ -15,16 +15,20 @@ from entities.laser import LaserFlash, SplashEffect
 from systems.combat import combat_step, PendingChain
 from systems.physics import clamp_units_to_bounds
 from systems.spawning import spawn_step
-from systems.selection import click_select, apply_circle_selection, select_all_of_type
+from systems.selection import (
+    click_select, apply_circle_selection, apply_rect_selection,
+    select_all_of_type, _deselect_all,
+)
 from systems.ai import BaseAI, WanderAI
 from systems.map_generator import BaseMapGenerator, DefaultMapGenerator
 from systems.capturing import capture_step
 from entities.metal_spot import MetalSpot
 from entities.metal_extractor import MetalExtractor
+from config import display as display_config
 from config.settings import (
     SELECTION_FILL_COLOR, SELECTION_RECT_COLOR,
     COMMAND_PATH_COLOR, COMMAND_DOT_COLOR, PATH_SAMPLE_MIN_DIST,
-    FIXED_DT, MAX_FRAME_DT, CC_RADIUS,
+    FIXED_DT, MAX_FRAME_DT, CC_RADIUS, CC_SPAWN_INTERVAL,
     PLAYER_COLORS, TEAM_COLORS, HEALTH_BAR_OFFSET,
     CAMERA_ZOOM_STEP, CAMERA_MAX_ZOOM,
     EDGE_PAN_MARGIN, EDGE_PAN_SPEED,
@@ -303,6 +307,8 @@ class Game:
             self._speed_slider = Slider(self._screen_width - 170, 10, 150, "Speed %", 25, 800, 100, 25)
             self._pause_btn = Button(self._screen_width - 210, 12, 32, 24, "||", icon="pause")
             self._reset_cam_btn = Button(70, 12, 50, 24, "Reset", font_size=18)
+            self._color_mode_btn = Button(130, 12, 60, 24, "Player", font_size=18)
+            self._color_mode: str = display.color_mode
             self._pause_font = pygame.font.SysFont(None, 48)
 
             # -- camera & world surface -------------------------------------------
@@ -321,6 +327,7 @@ class Game:
         self._phase: str = "warp_in"
         self._anim_timer: float = 0.0
         self._fragments: list[dict] = []
+        self._dying_units: list[dict] = []  # frozen draw data for staggered death
         if not server_mode:
             self._anim_surface = pygame.Surface((width, height), pygame.SRCALPHA)
             self._fog_surface = pygame.Surface((width, height), pygame.SRCALPHA)
@@ -547,17 +554,21 @@ class Game:
             return
         mx, my = pygame.mouse.get_pos()
         ga = self._game_area
-        if not ga.collidepoint(mx, my):
-            return
         dx = 0.0
         dy = 0.0
+        # Top edge pan uses absolute screen top so it doesn't interfere
+        # with the header controls (speed slider, etc.)
+        if my <= EDGE_PAN_MARGIN:
+            dy = EDGE_PAN_SPEED * dt
+        if not ga.collidepoint(mx, my):
+            if dy:
+                self._camera.pan(0, dy)
+            return
         if mx <= ga.left + EDGE_PAN_MARGIN:
             dx = EDGE_PAN_SPEED * dt
         elif mx >= ga.right - EDGE_PAN_MARGIN - 1:
             dx = -EDGE_PAN_SPEED * dt
-        if my <= ga.top + EDGE_PAN_MARGIN:
-            dy = EDGE_PAN_SPEED * dt
-        elif my >= ga.bottom - EDGE_PAN_MARGIN - 1:
+        if my >= ga.bottom - EDGE_PAN_MARGIN - 1:
             dy = -EDGE_PAN_SPEED * dt
         if dx or dy:
             self._camera.pan(dx, dy)
@@ -570,6 +581,19 @@ class Game:
             float(pos[0] - self._game_area.x),
             float(pos[1] - self._game_area.y),
         )
+
+    def _apply_color_mode(self) -> None:
+        """Recolor all units based on current color mode (player or team)."""
+        for e in self.entities:
+            if not isinstance(e, Unit):
+                continue
+            if self._color_mode == "team":
+                new_color = PLAYER_COLORS[(e.team - 1) % len(PLAYER_COLORS)]
+            else:
+                new_color = PLAYER_COLORS[(e.player_id - 1) % len(PLAYER_COLORS)]
+            e._base_color = new_color
+            if not e.selected:
+                e.color = new_color
 
     # -- events -------------------------------------------------------------
 
@@ -628,12 +652,76 @@ class Game:
                 self._camera.reset()
                 continue
 
+            if self._color_mode_btn.handle_event(event):
+                new_mode = "team" if self._color_mode == "player" else "player"
+                self._color_mode = new_mode
+                self._color_mode_btn.label = new_mode.title()
+                display_config.set_color_mode(new_mode)
+                self._apply_color_mode()
+                continue
+
             if not self._has_human:
                 continue
+
+            # -- Selection hotkeys -----------------------------------------
+            if event.type == pygame.KEYDOWN:
+                mods = pygame.key.get_mods()
+                if event.key == pygame.K_z and mods & pygame.KMOD_CTRL:
+                    # Select own CC
+                    _deselect_all(self.entities)
+                    for e in self.entities:
+                        if (isinstance(e, CommandCenter) and e.alive
+                                and e.team in self._selectable_teams):
+                            e.set_selected(True)
+                    continue
+                elif event.key == pygame.K_TAB:
+                    # Select all army units
+                    _deselect_all(self.entities)
+                    for e in self.entities:
+                        if (isinstance(e, Unit) and not e.is_building
+                                and e.selectable and e.alive):
+                            e.set_selected(True)
+                    continue
+                elif event.key == pygame.K_c and mods & pygame.KMOD_CTRL:
+                    # Expand selection to all matching unit types
+                    selected = [e for e in self.entities
+                                if isinstance(e, Unit) and e.selected and e.alive]
+                    types = {u.unit_type for u in selected}
+                    teams = {u.team for u in selected}
+                    if types:
+                        for e in self.entities:
+                            if (isinstance(e, Unit) and e.selectable and e.alive
+                                    and e.unit_type in types and e.team in teams):
+                                e.set_selected(True)
+                    continue
+                elif event.key == pygame.K_s:
+                    # Stop selected units
+                    selected = [e for e in self.entities
+                                if isinstance(e, Unit) and e.selected
+                                and not e.is_building and e.alive]
+                    if selected:
+                        by_player: dict[int, list[int]] = {}
+                        for u in selected:
+                            by_player.setdefault(u.player_id, []).append(u.entity_id)
+                        for pid, uids in by_player.items():
+                            self._command_queue.enqueue(GameCommand(
+                                type="stop", player_id=pid,
+                                tick=self._iteration, data={"unit_ids": uids},
+                            ))
+                    continue
 
             if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                 # HUD click — consume all clicks in the HUD area
                 if self._hud_rect.collidepoint(event.pos):
+                    # Minimap click — center camera
+                    minimap_world = gui.handle_minimap_click(
+                        event.pos[0], event.pos[1],
+                        self._screen_width, self._screen_height, self._hud_h,
+                        self.width, self.height,
+                    )
+                    if minimap_world is not None:
+                        self._camera.center_on(*minimap_world)
+                        continue
                     hud_result = gui.handle_hud_click(
                         self.entities, event.pos[0], event.pos[1],
                         self._screen_width, self._screen_height, self._hud_h,
@@ -687,11 +775,21 @@ class Game:
                     self._last_click_time = now
                     self._last_click_pos = event.pos  # screen space for distance check
                 else:
-                    cx, cy = self._selection_center()
-                    apply_circle_selection(
-                        self.entities, cx, cy, sr,
-                        additive=bool(shift),
-                    )
+                    if display_config.selection_mode == "rectangle":
+                        x1, y1 = self._drag_start
+                        x2, y2 = self._drag_end
+                        apply_rect_selection(
+                            self.entities, x1, y1, x2, y2,
+                            additive=bool(shift),
+                            own_player_ids=self._selectable_players,
+                        )
+                    else:
+                        cx, cy = self._selection_center()
+                        apply_circle_selection(
+                            self.entities, cx, cy, sr,
+                            additive=bool(shift),
+                            own_player_ids=self._selectable_players,
+                        )
                 self._dragging = False
 
             elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 3:
@@ -995,6 +1093,11 @@ class Game:
                 if isinstance(e, Unit):
                     self._quadfield.add_unit(e)
                     self.team_units.setdefault(e.team, []).append(e)
+                    # Apply color mode to newly spawned units
+                    if hasattr(self, '_color_mode') and self._color_mode == "team":
+                        new_color = PLAYER_COLORS[(e.team - 1) % len(PLAYER_COLORS)]
+                        e._base_color = new_color
+                        e.color = new_color
         self._stats.record_subsystem("spawn", (_perf() - _t) * 1000)
 
         _t = _perf()
@@ -1113,6 +1216,10 @@ class Game:
             losing_teams = self.all_teams - surviving_teams
             for t in losing_teams:
                 self._init_fragments(t)
+                self._init_unit_death(t)
+            # Prune dead units so they don't render during explode
+            self.entities = [e for e in self.entities if e.alive]
+            self.units = [u for u in self.units if u.alive]
 
         # Tick limit — score-based tiebreaker, then draw if still tied
         if self._max_ticks > 0 and self._iteration >= self._max_ticks and self._winner == 0:
@@ -1302,12 +1409,20 @@ class Game:
         if self._dragging:
             sr = self._selection_radius()
             if sr >= 5:
-                cx, cy = self._selection_center()
                 self._selection_surface.fill((0, 0, 0, 0))
-                pygame.draw.circle(self._selection_surface, SELECTION_FILL_COLOR,
-                                   (int(cx), int(cy)), int(sr))
-                pygame.draw.circle(self._selection_surface, SELECTION_RECT_COLOR,
-                                   (int(cx), int(cy)), int(sr), 1)
+                if display_config.selection_mode == "rectangle":
+                    x1, y1 = self._drag_start
+                    x2, y2 = self._drag_end
+                    rect = pygame.Rect(min(x1, x2), min(y1, y2),
+                                       abs(x2 - x1), abs(y2 - y1))
+                    pygame.draw.rect(self._selection_surface, SELECTION_FILL_COLOR, rect)
+                    pygame.draw.rect(self._selection_surface, SELECTION_RECT_COLOR, rect, 1)
+                else:
+                    cx, cy = self._selection_center()
+                    pygame.draw.circle(self._selection_surface, SELECTION_FILL_COLOR,
+                                       (int(cx), int(cy)), int(sr))
+                    pygame.draw.circle(self._selection_surface, SELECTION_RECT_COLOR,
+                                       (int(cx), int(cy)), int(sr), 1)
                 ws.blit(self._selection_surface, (0, 0))
 
         if self._rdragging and len(self._rpath) >= 2:
@@ -1319,7 +1434,7 @@ class Game:
             if selected_count > 0:
                 preview = self._resample_path(selected_count)
                 for px, py in preview:
-                    pygame.draw.circle(ws, COMMAND_DOT_COLOR, (int(px), int(py)), 4, 1)
+                    pygame.draw.circle(ws, COMMAND_PATH_COLOR, (int(px), int(py)), 5)
 
         # -- Composite to screen --
         self.screen.fill((0, 0, 0))
@@ -1333,6 +1448,7 @@ class Game:
         # Header widgets
         self._pause_btn.draw(self.screen)
         self._reset_cam_btn.draw(self.screen)
+        self._color_mode_btn.draw(self.screen)
         self._speed_slider.draw(self.screen)
         fps_val = self.clock.get_fps()
         fps_surf = self._fps_font.render(f"FPS: {fps_val:.0f}", True, (200, 200, 200))
@@ -1364,7 +1480,8 @@ class Game:
         if self._has_human:
             gui.draw_hud(self.screen, self.entities,
                          self._screen_width, self._screen_height, self._hud_h,
-                         enable_t2=self.enable_t2, t2_upgrades=self._t2_upgrades)
+                         enable_t2=self.enable_t2, t2_upgrades=self._t2_upgrades,
+                         camera=self._camera, world_w=self.width, world_h=self.height)
 
         # Paused overlay (centered on game area)
         if self._paused:
@@ -1498,9 +1615,52 @@ class Game:
                 "color": color,
             })
 
+    def _init_unit_death(self, team: int):
+        """Create staggered shard fragments for all units on the losing team."""
+        team_units = [u for u in self.units
+                      if u.team == team and u.alive and not isinstance(u, CommandCenter)]
+        random.shuffle(team_units)
+
+        for u in team_units:
+            delay = random.uniform(0.3, 2.5)
+            # Store draw data so we can draw the unit frozen until it explodes
+            self._dying_units.append({
+                "x": u.x, "y": u.y,
+                "radius": u.radius,
+                "color": u._base_color,
+                "delay": delay,
+            })
+            # Create 4-6 triangular shards from the circle
+            n_shards = random.randint(4, 6)
+            for j in range(n_shards):
+                a1 = math.tau * j / n_shards
+                a2 = math.tau * (j + 1) / n_shards
+                tri = [
+                    (0.0, 0.0),
+                    (u.radius * math.cos(a1), u.radius * math.sin(a1)),
+                    (u.radius * math.cos(a2), u.radius * math.sin(a2)),
+                ]
+                out_x = math.cos((a1 + a2) / 2)
+                out_y = math.sin((a1 + a2) / 2)
+                speed = random.uniform(30, 80)
+                self._fragments.append({
+                    "points": tri,
+                    "cx": u.x, "cy": u.y,
+                    "vx": out_x * speed + random.uniform(-15, 15),
+                    "vy": out_y * speed + random.uniform(-15, 15),
+                    "angle": 0.0,
+                    "rot_speed": random.uniform(-5, 5),
+                    "color": u._base_color,
+                    "delay": delay,
+                })
+            # Kill the unit
+            u.alive = False
+
     def _update_fragments(self, dt: float):
         """Move and rotate explosion fragments."""
         for frag in self._fragments:
+            if frag.get("delay", 0) > self._anim_timer:
+                continue  # not yet started
             frag["cx"] += frag["vx"] * dt
             frag["cy"] += frag["vy"] * dt
             frag["angle"] += frag["rot_speed"] * dt
@@ -1511,16 +1671,28 @@ class Game:
         # Draw all surviving entities normally
         for entity in self.entities:
             entity.draw(ws)
+
+        # Draw dying units that haven't exploded yet (frozen in place)
+        for du in self._dying_units:
+            if self._anim_timer < du["delay"]:
+                pygame.draw.circle(ws, du["color"],
+                                   (int(du["x"]), int(du["y"])), du["radius"])
+
         self._draw_fog()
 
-        # Draw explosion fragments
-        t = min(self._anim_timer / 3.0, 1.0)
-        alpha = int(255 * (1.0 - t))
-        if alpha <= 0:
-            return
-
+        # Draw explosion fragments (with per-fragment delay and fade)
         self._anim_surface.fill((0, 0, 0, 0))
+        any_drawn = False
         for frag in self._fragments:
+            delay = frag.get("delay", 0.0)
+            if self._anim_timer < delay:
+                continue  # not yet started
+            elapsed = self._anim_timer - delay
+            t = min(elapsed / 2.0, 1.0)  # fade over 2 seconds after delay
+            alpha = int(255 * (1.0 - t))
+            if alpha <= 0:
+                continue
+
             cos_a = math.cos(frag["angle"])
             sin_a = math.sin(frag["angle"])
             rotated = []
@@ -1531,8 +1703,10 @@ class Game:
 
             frag_color = (*frag["color"][:3], alpha)
             pygame.draw.polygon(self._anim_surface, frag_color, rotated)
+            any_drawn = True
 
-        ws.blit(self._anim_surface, (0, 0))
+        if any_drawn:
+            ws.blit(self._anim_surface, (0, 0))
 
     # -- headless snapshot ----------------------------------------------------
 
@@ -1610,6 +1784,8 @@ class Game:
 
         if self._headless:
             self._phase = "playing"  # skip warp_in
+            for cc in self.command_centers:
+                cc._spawn_timer = CC_SPAWN_INTERVAL
             headless_font = pygame.font.SysFont(None, 28)
             self._headless_snap_font = pygame.font.SysFont(None, 18)
             self._headless_snap_surf: pygame.Surface | None = None
@@ -1655,6 +1831,9 @@ class Game:
                     self._anim_timer += real_dt
                     if self._anim_timer >= 3.0:
                         self._phase = "playing"
+                        # CCs ready to spawn on first tick after warp-in
+                        for cc in self.command_centers:
+                            cc._spawn_timer = CC_SPAWN_INTERVAL
                     self.render()
 
                 elif self._phase == "playing":
@@ -1674,7 +1853,7 @@ class Game:
                 elif self._phase == "explode":
                     self._anim_timer += real_dt
                     self._update_fragments(real_dt)
-                    if self._anim_timer >= 3.0:
+                    if self._anim_timer >= 4.5:
                         self.running = False
                     self.render()
 
@@ -1754,6 +1933,25 @@ class Game:
 
         self.running = True
         self._phase = "playing"
+
+        # -- Warp-in delay: wait 3s so client can show the warp-in
+        # animation.  Accept commands (so player can pick spawn type)
+        # but don't step the simulation.
+        warp_end = time.perf_counter() + 3.0
+        while self.running and time.perf_counter() < warp_end:
+            if pre_step:
+                pre_step()
+            # Apply commands (set_spawn_type, set_speed, etc.)
+            for cmd in self._command_queue.drain(self._iteration + 999999):
+                self._apply_command(cmd)
+            if post_step:
+                post_step(self._iteration, self.entities,
+                          self.laser_flashes, self._winner)
+            time.sleep(0.016)
+
+        # Set CCs ready to spawn on first tick
+        for cc in self.command_centers:
+            cc._spawn_timer = CC_SPAWN_INTERVAL
 
         tick_interval = FIXED_DT / 1.0  # ~16.67ms at 60 ticks/sec
         next_tick = time.perf_counter()

--- a/gui.py
+++ b/gui.py
@@ -171,13 +171,16 @@ def _research_btn_rects(ar: pygame.Rect) -> list[tuple[pygame.Rect, str]]:
 
 def draw_hud(screen: pygame.Surface, entities,
              width: int, height: int, hud_h: int,
-             enable_t2: bool = False, t2_upgrades: dict | None = None):
+             enable_t2: bool = False, t2_upgrades: dict | None = None,
+             camera=None, world_w: int = 0, world_h: int = 0,
+             obstacles=None):
     """Draw the full HUD bar at the bottom of the screen."""
     minimap, display, portrait, action = _hud_sections(width, height, hud_h)
     selected = _get_selected(entities)
     cc = get_selected_cc(entities)
 
-    _draw_minimap(screen, minimap)
+    _draw_minimap(screen, minimap, entities, camera, world_w, world_h,
+                  obstacles=obstacles)
     _draw_display(screen, display, selected, t2_upgrades=t2_upgrades)
     _draw_portrait(screen, portrait, selected)
     _draw_actions(screen, action, selected, cc, enable_t2=enable_t2, t2_upgrades=t2_upgrades)
@@ -188,11 +191,133 @@ def draw_hud(screen: pygame.Surface, entities,
                          (r.right - 1, r.top), (r.right - 1, r.bottom))
 
 
-def _draw_minimap(screen: pygame.Surface, r: pygame.Rect):
+def _draw_minimap(screen: pygame.Surface, r: pygame.Rect,
+                  entities=None, camera=None,
+                  world_w: int = 0, world_h: int = 0,
+                  obstacles=None):
     pygame.draw.rect(screen, _MINIMAP_BG, r)
-    t = _font(14).render("MINIMAP", True, (50, 50, 65))
-    screen.blit(t, (r.centerx - t.get_width() // 2,
-                    r.centery - t.get_height() // 2))
+
+    if not entities or world_w <= 0 or world_h <= 0:
+        t = _font(14).render("MINIMAP", True, (50, 50, 65))
+        screen.blit(t, (r.centerx - t.get_width() // 2,
+                        r.centery - t.get_height() // 2))
+        return
+
+    pad = 4
+    inner_w = r.width - pad * 2
+    inner_h = r.height - pad * 2
+    sx = inner_w / world_w
+    sy = inner_h / world_h
+    scale = min(sx, sy)
+    mw = world_w * scale
+    mh = world_h * scale
+    ox = r.left + pad + (inner_w - mw) / 2
+    oy = r.top + pad + (inner_h - mh) / 2
+
+    def w2m(wx: float, wy: float) -> tuple[int, int]:
+        return int(ox + wx * scale), int(oy + wy * scale)
+
+    # Clip drawing to minimap area
+    screen.set_clip(r)
+
+    from entities.metal_spot import MetalSpot
+    from entities.shapes import RectEntity, CircleEntity
+    from config.settings import TEAM_COLORS, OBSTACLE_COLOR
+
+    def _is_ms(e):
+        return isinstance(e, MetalSpot) or getattr(e, '_is_metal_spot', False)
+
+    def _is_me(e):
+        return isinstance(e, MetalExtractor) or getattr(e, '_is_metal_extractor', False)
+
+    def _is_unit(e):
+        return (isinstance(e, Unit) or getattr(e, '_is_unit', False)) and not getattr(e, 'is_building', False) and not _is_ms(e) and not _is_me(e) and not _is_cc(e)
+
+    def _is_cc(e):
+        return isinstance(e, CommandCenter) or getattr(e, '_is_command_center', False)
+
+    # Obstacles (grey) — from real entities or separate obstacle dicts
+    for e in entities:
+        if getattr(e, "obstacle", False) and getattr(e, "alive", False):
+            mx, my = w2m(e.x, e.y)
+            if isinstance(e, RectEntity):
+                hw = max(1, int(e.width * scale / 2))
+                hh = max(1, int(e.height * scale / 2))
+                pygame.draw.rect(screen, (80, 80, 80),
+                                 (mx - hw, my - hh, hw * 2, hh * 2))
+            else:
+                mr = max(1, int(getattr(e, "radius", 3) * scale))
+                pygame.draw.circle(screen, (80, 80, 80), (mx, my), mr)
+    # Obstacles from separate dict list (client-side)
+    if obstacles:
+        for obs in obstacles:
+            if obs.get("shape") == "rect":
+                ox2, oy2 = w2m(obs["x"], obs["y"])
+                ow = max(1, int(obs["w"] * scale))
+                oh = max(1, int(obs["h"] * scale))
+                pygame.draw.rect(screen, (80, 80, 80), (ox2, oy2, ow, oh))
+            elif obs.get("shape") == "circle":
+                ox2, oy2 = w2m(obs["x"], obs["y"])
+                orr = max(1, int(obs["r"] * scale))
+                pygame.draw.circle(screen, (80, 80, 80), (ox2, oy2), orr)
+
+    # Metal spots (small triangles)
+    for e in entities:
+        if _is_ms(e) and getattr(e, "alive", True):
+            mx, my = w2m(e.x, e.y)
+            s = max(2, int(4 * scale))
+            pts = [(mx, my - s), (mx - s, my + s), (mx + s, my + s)]
+            owner = getattr(e, "owner", None)
+            if owner is None:
+                color = (255, 255, 255)
+            else:
+                color = TEAM_COLORS.get(owner, (255, 255, 255))
+            pygame.draw.polygon(screen, color, pts)
+
+    # Metal extractors (colored triangles)
+    for e in entities:
+        if _is_me(e) and getattr(e, "alive", True):
+            mx, my = w2m(e.x, e.y)
+            s = max(2, int(5 * scale))
+            pts = [(mx, my - s), (mx - s, my + s), (mx + s, my + s)]
+            color = PLAYER_COLORS[(getattr(e, "team", 1) - 1) % len(PLAYER_COLORS)]
+            pygame.draw.polygon(screen, color, pts)
+
+    # Units (small circles)
+    for e in entities:
+        if _is_unit(e) and getattr(e, "alive", True):
+            mx, my = w2m(e.x, e.y)
+            mr = max(1, int(getattr(e, "radius", 5) * scale * 0.6))
+            pygame.draw.circle(screen, getattr(e, "color", (200, 200, 200)), (mx, my), mr)
+
+    # Command centers (small octagons)
+    for e in entities:
+        if _is_cc(e) and getattr(e, "alive", True):
+            mx, my = w2m(e.x, e.y)
+            s = max(3, int(20 * scale))
+            pts = []
+            for i in range(8):
+                a = math.tau * i / 8
+                pts.append((mx + int(s * math.cos(a)),
+                            my + int(s * math.sin(a))))
+            color = PLAYER_COLORS[(getattr(e, "player_id", 1) - 1) % len(PLAYER_COLORS)]
+            pygame.draw.polygon(screen, color, pts)
+
+    # Camera viewport rectangle
+    if camera is not None:
+        vp = camera.get_world_viewport_rect()
+        cx1, cy1 = w2m(max(0, vp.left), max(0, vp.top))
+        cx2, cy2 = w2m(min(world_w, vp.right), min(world_h, vp.bottom))
+        cam_w = max(1, cx2 - cx1)
+        cam_h = max(1, cy2 - cy1)
+        cam_rect = pygame.Rect(cx1, cy1, cam_w, cam_h)
+        # Clip to minimap world area
+        mini_world = pygame.Rect(int(ox), int(oy), int(mw), int(mh))
+        cam_rect = cam_rect.clip(mini_world)
+        if cam_rect.width > 0 and cam_rect.height > 0:
+            pygame.draw.rect(screen, (255, 255, 255), cam_rect, 1)
+
+    screen.set_clip(None)
 
 
 # ── unit / group display ────────────────────────────────────────────
@@ -680,6 +805,31 @@ def _draw_tooltip(screen: pygame.Surface, utype: str,
 
 
 # ── click handling ───────────────────────────────────────────────────
+
+def handle_minimap_click(mx: int, my: int,
+                         width: int, height: int, hud_h: int,
+                         world_w: int, world_h: int) -> tuple[float, float] | None:
+    """If (mx, my) is inside the minimap, return corresponding world coords."""
+    minimap, _, _, _ = _hud_sections(width, height, hud_h)
+    if not minimap.collidepoint(mx, my):
+        return None
+    if world_w <= 0 or world_h <= 0:
+        return None
+    pad = 4
+    inner_w = minimap.width - pad * 2
+    inner_h = minimap.height - pad * 2
+    sx = inner_w / world_w
+    sy = inner_h / world_h
+    scale = min(sx, sy)
+    mw = world_w * scale
+    mh = world_h * scale
+    ox = minimap.left + pad + (inner_w - mw) / 2
+    oy = minimap.top + pad + (inner_h - mh) / 2
+    wx = (mx - ox) / scale
+    wy = (my - oy) / scale
+    wx = max(0.0, min(float(world_w), wx))
+    wy = max(0.0, min(float(world_h), wy))
+    return (wx, wy)
 
 def handle_hud_click(entities, mx: int, my: int,
                      width: int, height: int, hud_h: int,

--- a/gui_adapter.py
+++ b/gui_adapter.py
@@ -14,6 +14,7 @@ class _EntityProxy(SimpleNamespace):
     """Lightweight proxy that quacks like an entity for gui.py."""
     _is_command_center: bool = False
     _is_metal_extractor: bool = False
+    _is_metal_spot: bool = False
     _is_unit: bool = False
 
 
@@ -106,6 +107,10 @@ def _make_proxy(d: dict, selected_ids: set[int]) -> _EntityProxy:
         def get_spawn_bonus(self=p, _b=_meb):
             return _b / 100.0
         p.get_spawn_bonus = get_spawn_bonus
+
+    elif t == "MS":
+        p._is_metal_spot = True
+        p.owner = d.get("ow")
 
     elif t == "U":
         p._is_unit = True

--- a/networking/host.py
+++ b/networking/host.py
@@ -155,7 +155,10 @@ class GameHost:
         """Shut down the server and networking thread."""
         self._running = False
         if self._loop is not None:
-            self._loop.call_soon_threadsafe(self._loop.stop)
+            try:
+                self._loop.call_soon_threadsafe(self._loop.stop)
+            except RuntimeError:
+                pass  # event loop already closed
         if self._thread is not None:
             self._thread.join(timeout=2.0)
 
@@ -200,12 +203,19 @@ class GameHost:
         with self._clients_lock:
             for c in self._clients.values():
                 if c.connected.is_set():
-                    # Drop old unsent frames — keep only latest
+                    # Drop old stale STATE frames — keep only the latest.
+                    # Preserve non-state messages (game_start, game_over, etc.)
+                    # so they are never silently discarded.
+                    preserved = []
                     try:
                         while True:
-                            c.outbound.get_nowait()
+                            old = c.outbound.get_nowait()
+                            if old.get("msg") != "state":
+                                preserved.append(old)
                     except queue.Empty:
                         pass
+                    for item in preserved:
+                        c.outbound.put(item)
                     c.outbound.put(frame)
 
     def send_game_start(

--- a/screens/client_game.py
+++ b/screens/client_game.py
@@ -32,6 +32,7 @@ from ui.widgets import _get_font, Slider, Button
 import gui
 from gui_adapter import wrap_entities
 from systems.replay import normalize_cp
+from config import display as display_config
 
 _STATUS_COLOR = (180, 180, 200)
 _DISCONNECT_COLOR = (255, 100, 100)
@@ -119,7 +120,7 @@ class ClientGameScreen(BaseScreen):
         # Right-click path drawing
         self._rdragging = False
         self._rpath: list[tuple[float, float]] = []
-        self._PATH_MIN_DIST = 10.0
+        self._PATH_MIN_DIST = 2.5
 
         # Selection surface for circle draw
         self._selection_surface = pygame.Surface((mw, mh), pygame.SRCALPHA)
@@ -278,6 +279,55 @@ class ClientGameScreen(BaseScreen):
                         and self._is_local):
                     self._toggle_pause()
 
+                # Selection hotkeys
+                if event.type == pygame.KEYDOWN:
+                    mods = pygame.key.get_mods()
+                    if event.key == pygame.K_z and mods & pygame.KMOD_CTRL:
+                        # Select own CC
+                        self._selected_ids.clear()
+                        for ent in self._entities:
+                            if ent.get("t") == "CC" and ent.get("tm") == self._my_team:
+                                eid = ent.get("id")
+                                if eid is not None:
+                                    self._selected_ids.add(eid)
+                    elif event.key == pygame.K_TAB:
+                        # Select all army units
+                        self._selected_ids.clear()
+                        for ent in self._entities:
+                            if ent.get("t") == "U" and ent.get("tm") == self._my_team:
+                                eid = ent.get("id")
+                                if eid is not None:
+                                    self._selected_ids.add(eid)
+                    elif event.key == pygame.K_c and mods & pygame.KMOD_CTRL:
+                        # Expand selection to all matching unit types
+                        sel_types = set()
+                        for ent in self._entities:
+                            if (ent.get("t") == "U"
+                                    and ent.get("id") in self._selected_ids):
+                                sel_types.add(ent.get("ut"))
+                        if sel_types:
+                            for ent in self._entities:
+                                if (ent.get("t") == "U"
+                                        and ent.get("tm") == self._my_team
+                                        and ent.get("ut") in sel_types):
+                                    eid = ent.get("id")
+                                    if eid is not None:
+                                        self._selected_ids.add(eid)
+                    elif event.key == pygame.K_s:
+                        # Stop selected units
+                        stop_ids = [
+                            ent.get("id") for ent in self._entities
+                            if ent.get("t") == "U"
+                            and ent.get("id") in self._selected_ids
+                        ]
+                        if stop_ids:
+                            self._client.send_command(GameCommand(
+                                type="stop",
+                                player_id=self._my_team,
+                                tick=self._tick,
+                                data={"unit_ids": stop_ids},
+                            ))
+
                 # Header bar interactions (local controls)
                 if (event.type == pygame.MOUSEBUTTONDOWN and event.button == 1
                         and self._is_local and self._header_rect.collidepoint(event.pos)):
@@ -326,6 +376,15 @@ class ClientGameScreen(BaseScreen):
                 # Left click — HUD or selection
                 if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                     if self._hud_rect.collidepoint(event.pos):
+                        # Minimap click — center camera
+                        minimap_world = gui.handle_minimap_click(
+                            event.pos[0], event.pos[1],
+                            self.width, self.height, self._hud_h,
+                            self._map_w, self._map_h,
+                        )
+                        if minimap_world is not None:
+                            self._camera.center_on(*minimap_world)
+                            continue
                         self._handle_hud_click(event.pos)
                         # Check if a unit in the group grid was clicked
                         self._handle_display_click(event.pos)
@@ -432,29 +491,57 @@ class ClientGameScreen(BaseScreen):
                             if eid is not None:
                                 self._selected_ids.add(eid)
         else:
-            # Circle select (center = drag start, radius = distance to release)
-            # Army units take priority over buildings
+            # Drag select — army units take priority over buildings
             if not additive:
                 self._selected_ids.clear()
-            ccx, ccy = self._screen_to_world(self._drag_start)
-            w_ex, w_ey = self._screen_to_world(pos)
-            sr = math.hypot(w_ex - ccx, w_ey - ccy)
             army_ids: list[int] = []
             building_ids: list[int] = []
-            for ent in self._entities:
-                if ent.get("tm") != self._my_team:
-                    continue
-                t = ent.get("t")
-                if t not in ("U", "CC", "ME"):
-                    continue
-                ex, ey = ent.get("x", 0), ent.get("y", 0)
-                if math.hypot(ex - ccx, ey - ccy) <= sr:
-                    eid = ent.get("id")
-                    if eid is not None:
-                        if t == "U":
-                            army_ids.append(eid)
-                        else:
-                            building_ids.append(eid)
+
+            if display_config.selection_mode == "rectangle":
+                # Rectangle select: corners are drag_start and release pos
+                wx1, wy1 = self._screen_to_world(self._drag_start)
+                wx2, wy2 = self._screen_to_world(pos)
+                rx = min(wx1, wx2)
+                ry = min(wy1, wy2)
+                rw = abs(wx2 - wx1)
+                rh = abs(wy2 - wy1)
+                rcx, rcy = rx + rw / 2, ry + rh / 2
+                hw, hh = rw / 2, rh / 2
+                for ent in self._entities:
+                    if ent.get("tm") != self._my_team:
+                        continue
+                    t = ent.get("t")
+                    if t not in ("U", "CC", "ME"):
+                        continue
+                    ex, ey = ent.get("x", 0), ent.get("y", 0)
+                    er = ent.get("r", 5)
+                    if abs(ex - rcx) <= hw + er and abs(ey - rcy) <= hh + er:
+                        eid = ent.get("id")
+                        if eid is not None:
+                            if t == "U":
+                                army_ids.append(eid)
+                            else:
+                                building_ids.append(eid)
+            else:
+                # Circle select (center = drag start, radius = distance to release)
+                ccx, ccy = self._screen_to_world(self._drag_start)
+                w_ex, w_ey = self._screen_to_world(pos)
+                sr = math.hypot(w_ex - ccx, w_ey - ccy)
+                for ent in self._entities:
+                    if ent.get("tm") != self._my_team:
+                        continue
+                    t = ent.get("t")
+                    if t not in ("U", "CC", "ME"):
+                        continue
+                    ex, ey = ent.get("x", 0), ent.get("y", 0)
+                    if math.hypot(ex - ccx, ey - ccy) <= sr:
+                        eid = ent.get("id")
+                        if eid is not None:
+                            if t == "U":
+                                army_ids.append(eid)
+                            else:
+                                building_ids.append(eid)
+
             targets = army_ids if army_ids else building_ids
             for eid in targets:
                 self._selected_ids.add(eid)
@@ -808,7 +895,8 @@ class ClientGameScreen(BaseScreen):
                 if not is_warp_in:
                     self._draw_command_center(ent)
             elif t == "U":
-                self._draw_unit(ent)
+                if not is_warp_in:
+                    self._draw_unit(ent)
 
         # Warp-in animation overlays CCs with scale + glow
         if is_warp_in:
@@ -873,30 +961,48 @@ class ClientGameScreen(BaseScreen):
         # Team labels
         self._draw_team_labels(entities)
 
-        # Drag selection circle (center = drag start, radius = distance to cursor)
+        # Drag selection visual
         if self._dragging:
             sx, sy = self._drag_start
             ex, ey = self._drag_end
             screen_r = math.hypot(ex - sx, ey - sy)
             if screen_r >= 5:
-                wcx, wcy = self._screen_to_world(self._drag_start)
-                w_ex, w_ey = self._screen_to_world(self._drag_end)
-                wr = math.hypot(w_ex - wcx, w_ey - wcy)
                 self._selection_surface.fill((0, 0, 0, 0))
-                pygame.draw.circle(self._selection_surface, SELECTION_FILL_COLOR,
-                                   (int(wcx), int(wcy)), int(wr))
-                pygame.draw.circle(self._selection_surface, SELECTION_RECT_COLOR,
-                                   (int(wcx), int(wcy)), int(wr), 1)
+                if display_config.selection_mode == "rectangle":
+                    wcx1, wcy1 = self._screen_to_world(self._drag_start)
+                    wcx2, wcy2 = self._screen_to_world(self._drag_end)
+                    rx = min(wcx1, wcx2)
+                    ry = min(wcy1, wcy2)
+                    rw = abs(wcx2 - wcx1)
+                    rh = abs(wcy2 - wcy1)
+                    rect = pygame.Rect(int(rx), int(ry), int(rw), int(rh))
+                    pygame.draw.rect(self._selection_surface, SELECTION_FILL_COLOR, rect)
+                    pygame.draw.rect(self._selection_surface, SELECTION_RECT_COLOR, rect, 1)
+                else:
+                    wcx, wcy = self._screen_to_world(self._drag_start)
+                    w_ex, w_ey = self._screen_to_world(self._drag_end)
+                    wr = math.hypot(w_ex - wcx, w_ey - wcy)
+                    pygame.draw.circle(self._selection_surface, SELECTION_FILL_COLOR,
+                                       (int(wcx), int(wcy)), int(wr))
+                    pygame.draw.circle(self._selection_surface, SELECTION_RECT_COLOR,
+                                       (int(wcx), int(wcy)), int(wr), 1)
                 ws.blit(self._selection_surface, (0, 0))
 
-        # Right-click path with dots
+        # Right-click path with unit-count dots
         if self._rdragging and len(self._rpath) > 1:
+            path_color = (0, 200, 60)
             for i in range(1, len(self._rpath)):
                 ax, ay = self._rpath[i - 1]
                 bx, by = self._rpath[i]
-                pygame.draw.line(ws, (0, 200, 60), (ax, ay), (bx, by), 1)
-            for px, py in self._rpath:
-                pygame.draw.circle(ws, (0, 240, 80), (int(px), int(py)), 3)
+                pygame.draw.line(ws, path_color, (ax, ay), (bx, by), 1)
+            selected_count = sum(
+                1 for e in self._entities
+                if e.get("id") in self._selected_ids and e.get("t") == "U"
+            )
+            if selected_count > 0:
+                preview = self._resample_path(selected_count)
+                for px, py in preview:
+                    pygame.draw.circle(ws, path_color, (int(px), int(py)), 3)
 
         # Fog of war
         self._draw_fog(entities)
@@ -1003,6 +1109,10 @@ class ClientGameScreen(BaseScreen):
             self.width, self.height, self._hud_h,
             enable_t2=self._enable_t2,
             t2_upgrades=self._t2_upgrades,
+            camera=self._camera,
+            world_w=self._map_w,
+            world_h=self._map_h,
+            obstacles=self._obstacles,
         )
 
     # -- entity drawing (adapted from ReplayPlaybackScreen) -----------------

--- a/screens/options.py
+++ b/screens/options.py
@@ -40,6 +40,32 @@ class OptionsScreen(BaseScreen):
             btn_h=32,
         )
 
+        # Color mode toggle
+        color_idx = 0 if display_config.color_mode == "player" else 1
+        self._color_toggle = ToggleGroup(
+            self.width // 2 - 145, self.height // 2 + 110,
+            [
+                ("player", "Player Colors"),
+                ("team", "Team Colors"),
+            ],
+            selected_index=color_idx,
+            btn_w=140,
+            btn_h=32,
+        )
+
+        # Selection mode toggle
+        sel_idx = 0 if display_config.selection_mode == "rectangle" else 1
+        self._selection_toggle = ToggleGroup(
+            self.width // 2 - 145, self.height // 2 + 190,
+            [
+                ("rectangle", "Rectangle"),
+                ("circle", "Circle"),
+            ],
+            selected_index=sel_idx,
+            btn_w=140,
+            btn_h=32,
+        )
+
     def _apply_display_mode(self):
         mode = self._display_toggle.value
         display_config.set_mode(mode)
@@ -54,6 +80,10 @@ class OptionsScreen(BaseScreen):
         self._volume_slider.w = sl_w
         self._display_toggle.x = self.width // 2 - 145
         self._display_toggle.y = self.height // 2 + 30
+        self._color_toggle.x = self.width // 2 - 145
+        self._color_toggle.y = self.height // 2 + 110
+        self._selection_toggle.x = self.width // 2 - 145
+        self._selection_toggle.y = self.height // 2 + 190
 
     def run(self) -> ScreenResult:
         while True:
@@ -74,6 +104,12 @@ class OptionsScreen(BaseScreen):
                 if self._display_toggle.handle_event(event):
                     self._apply_display_mode()
 
+                if self._color_toggle.handle_event(event):
+                    display_config.set_color_mode(self._color_toggle.value)
+
+                if self._selection_toggle.handle_event(event):
+                    display_config.set_selection_mode(self._selection_toggle.value)
+
             self._draw()
 
     def _draw(self):
@@ -85,15 +121,25 @@ class OptionsScreen(BaseScreen):
         tx = self.width // 2 - title.get_width() // 2
         self.screen.blit(title, (tx, 80))
 
-        # Display mode label
+        # Labels
         label_font = _get_font(18)
         dm_label = label_font.render("Display Mode", True, CONTENT_TEXT)
         self.screen.blit(dm_label, (self.width // 2 - dm_label.get_width() // 2,
                                     self._display_toggle.y - 24))
 
+        cm_label = label_font.render("Color Mode", True, CONTENT_TEXT)
+        self.screen.blit(cm_label, (self.width // 2 - cm_label.get_width() // 2,
+                                    self._color_toggle.y - 24))
+
+        sm_label = label_font.render("Selection Mode", True, CONTENT_TEXT)
+        self.screen.blit(sm_label, (self.width // 2 - sm_label.get_width() // 2,
+                                    self._selection_toggle.y - 24))
+
         # Widgets
         self._back.draw(self.screen)
         self._volume_slider.draw(self.screen)
         self._display_toggle.draw(self.screen)
+        self._color_toggle.draw(self.screen)
+        self._selection_toggle.draw(self.screen)
 
         pygame.display.flip()

--- a/systems/map_generator.py
+++ b/systems/map_generator.py
@@ -121,7 +121,6 @@ class DefaultMapGenerator(BaseMapGenerator):
                     sy = height * (j + 1) / (m + 1)
                     cc = CommandCenter(sx, sy, team=tid, player_id=pid)
                     cc._bounds = (width, height)
-                    cc._spawn_timer = CC_SPAWN_INTERVAL
                     entities.append(cc)
         else:
             # Radial placement for 3+ teams
@@ -144,7 +143,6 @@ class DefaultMapGenerator(BaseMapGenerator):
                         px, py = sx, sy
                     cc = CommandCenter(px, py, team=tid, player_id=pid)
                     cc._bounds = (width, height)
-                    cc._spawn_timer = CC_SPAWN_INTERVAL
                     entities.append(cc)
 
     def _place_metal_spots(self, entities: list[Entity], width: int, height: int,

--- a/systems/selection.py
+++ b/systems/selection.py
@@ -1,8 +1,67 @@
-"""Selection system: circle-drag and click-to-select."""
+"""Selection system: circle-drag, rectangle-drag, and click-to-select."""
 from __future__ import annotations
 import math
 from entities.base import Entity
 from entities.unit import Unit
+
+
+def entity_in_rect(
+    entity: Entity,
+    x1: float, y1: float, x2: float, y2: float,
+) -> bool:
+    """Check if an entity's circle overlaps an axis-aligned rectangle."""
+    ex, ey = entity.center()
+    er = entity.collision_radius()
+    rx = min(x1, x2)
+    ry = min(y1, y2)
+    rw = abs(x2 - x1)
+    rh = abs(y2 - y1)
+    # Closest point on rect to circle center
+    closest_x = max(rx, min(ex, rx + rw))
+    closest_y = max(ry, min(ey, ry + rh))
+    return math.hypot(ex - closest_x, ey - closest_y) <= er
+
+
+def apply_rect_selection(
+    entities: list[Entity],
+    x1: float, y1: float, x2: float, y2: float,
+    additive: bool,
+    own_player_ids: set[int] | None = None,
+):
+    """Select entities within an axis-aligned rectangle.
+
+    If *own_player_ids* is given and any matching army unit is inside,
+    only own units are selected.
+    """
+    if not additive:
+        _deselect_all(entities)
+
+    army_units: list[Entity] = []
+    own_army: list[Entity] = []
+    buildings: list[Entity] = []
+    for entity in entities:
+        if not getattr(entity, "selectable", False):
+            continue
+        if not entity_in_rect(entity, x1, y1, x2, y2):
+            continue
+        if getattr(entity, "is_building", False):
+            buildings.append(entity)
+        else:
+            army_units.append(entity)
+            if own_player_ids and hasattr(entity, "player_id"):
+                if entity.player_id in own_player_ids:
+                    own_army.append(entity)
+
+    # Prefer own army > all army > buildings
+    if own_army:
+        targets = own_army
+    elif army_units:
+        targets = army_units
+    else:
+        targets = buildings
+
+    for entity in targets:
+        entity.set_selected(True)
 
 
 def entity_in_circle(
@@ -58,12 +117,14 @@ def apply_circle_selection(
     entities: list[Entity],
     cx: float, cy: float, sr: float,
     additive: bool,
+    own_player_ids: set[int] | None = None,
 ):
     if not additive:
         _deselect_all(entities)
 
-    army_units = []
-    buildings = []
+    army_units: list[Entity] = []
+    own_army: list[Entity] = []
+    buildings: list[Entity] = []
     for entity in entities:
         if not getattr(entity, "selectable", False):
             continue
@@ -73,9 +134,17 @@ def apply_circle_selection(
             buildings.append(entity)
         else:
             army_units.append(entity)
+            if own_player_ids and hasattr(entity, "player_id"):
+                if entity.player_id in own_player_ids:
+                    own_army.append(entity)
 
-    # Army units take priority; fall back to buildings if none
-    targets = army_units if army_units else buildings
+    # Prefer own army > all army > buildings
+    if own_army:
+        targets = own_army
+    elif army_units:
+        targets = army_units
+    else:
+        targets = buildings
     for entity in targets:
         entity.set_selected(True)
 


### PR DESCRIPTION
- Selection system: add `apply_rect_selection`, `entity_in_rect`, and
  `select_all_of_type`; double-click selects all on-screen units of the
  same type; drag-select respects the new rectangle/circle mode setting
- Keyboard shortcuts: Ctrl+Z → select own CC, Tab → select all army,
  Ctrl+C → expand to all matching types, S → stop units; mirrored in
  both `game.py` and `screens/client_game.py`
- Options screen: add "Selection Mode" toggle (rectangle / circle)
  persisted via `config/display.py` and `display_settings.json`
- Map generator: add radial CC/metal-spot placement for 3+ teams; guard
  obstacles against overlapping CCs via exclusion zone
- Multiplayer: host/client networking and `gui_adapter` cleanups to
  support the new selection and color-mode features